### PR TITLE
refactor: use `SquareUtils` instead of **traits**

### DIFF
--- a/chess/src/board/bitboard.rs
+++ b/chess/src/board/bitboard.rs
@@ -1,8 +1,4 @@
-use super::{
-	file_rank::FileRankConsts,
-	square::{GetSquare, SquareConsts},
-	File, Rank, Square,
-};
+use super::{file_rank::FileRankConsts, square::SquareUtils, File, Rank, Square};
 
 pub type Bitboard = u64;
 
@@ -24,7 +20,7 @@ pub trait BitboardRanks {
 
 pub trait BitboardSquares {
 	#[rustfmt::skip]
-	const SQUARES: [Bitboard; usize::SQUARE_SIZE] = [
+	const SQUARES: [Bitboard; SquareUtils::SIZE] = [
 		0x0000000000000001, 0x0000000000000002, 0x0000000000000004, 0x0000000000000008,
 		0x0000000000000010, 0x0000000000000020, 0x0000000000000040, 0x0000000000000080,
 		0x0000000000000100, 0x0000000000000200, 0x0000000000000400, 0x0000000000000800,
@@ -88,7 +84,7 @@ impl BitboardString for Bitboard {
 
 		for rank in Rank::FILE_RANK_RANGE.rev() {
 			for file in File::FILE_RANK_RANGE {
-				let square = usize::get_square((file, rank));
+				let square = SquareUtils::from_location(file, rank);
 
 				string.push_str(match self.occupied(square) {
 					true => "1 ",

--- a/chess/src/board/castle_right.rs
+++ b/chess/src/board/castle_right.rs
@@ -1,4 +1,4 @@
-use super::{square::SquareConsts, square::Squares, Square};
+use super::square::SquareUtils;
 
 pub type CastleRight = u8;
 
@@ -19,16 +19,16 @@ pub trait CastleRights {
 }
 
 pub trait CastleRightSquares {
-	const SQUARES: [CastleRight; usize::SQUARE_SIZE] = {
-		let mut squares = [CastleRight::NONE; usize::SQUARE_SIZE];
+	const SQUARES: [CastleRight; SquareUtils::SIZE] = {
+		let mut squares = [CastleRight::NONE; SquareUtils::SIZE];
 
-		squares[Square::A1] = CastleRight::WHITE_QUEEN;
-		squares[Square::E1] = CastleRight::WHITE_KING | CastleRight::WHITE_QUEEN;
-		squares[Square::H1] = CastleRight::WHITE_KING;
+		squares[SquareUtils::A1] = CastleRight::WHITE_QUEEN;
+		squares[SquareUtils::E1] = CastleRight::WHITE_KING | CastleRight::WHITE_QUEEN;
+		squares[SquareUtils::H1] = CastleRight::WHITE_KING;
 
-		squares[Square::A8] = CastleRight::BLACK_QUEEN;
-		squares[Square::E8] = CastleRight::BLACK_KING | CastleRight::BLACK_QUEEN;
-		squares[Square::H8] = CastleRight::BLACK_KING;
+		squares[SquareUtils::A8] = CastleRight::BLACK_QUEEN;
+		squares[SquareUtils::E8] = CastleRight::BLACK_KING | CastleRight::BLACK_QUEEN;
+		squares[SquareUtils::H8] = CastleRight::BLACK_KING;
 
 		squares
 	};

--- a/chess/src/board/impls/display.rs
+++ b/chess/src/board/impls/display.rs
@@ -1,6 +1,6 @@
 use castle_right::CastleRightString;
 use file_rank::Ranks;
-use square::SquareString;
+use square::SquareUtils;
 
 use super::*;
 use super::{
@@ -8,7 +8,6 @@ use super::{
 	color::{ColorConsts, ColorString},
 	file_rank::FileRankConsts,
 	piece::PieceString,
-	square::GetSquare,
 };
 use std::fmt;
 
@@ -42,7 +41,7 @@ impl Board {
 			board += &format!(" {rank} ");
 
 			for file in usize::FILE_RANK_RANGE {
-				let piece = match self.get_piece(Square::get_square((file, rank))) {
+				let piece = match self.get_piece(SquareUtils::from_location(file, rank)) {
 					Some((piece, color)) => piece.piece_string(color),
 					None => " ".to_string(),
 				};
@@ -63,7 +62,7 @@ impl Board {
 			let mut empty = 0;
 
 			for file in usize::FILE_RANK_RANGE {
-				let square = Square::get_square((file, rank));
+				let square = SquareUtils::from_location(file, rank);
 
 				match self.get_piece(square) {
 					Some((piece, color)) => {
@@ -91,7 +90,7 @@ impl Board {
 		let castle_rights = &self.castle_rights.castle_right_string();
 
 		let en_passant = match self.en_passant {
-			Some(square) => square.square_string(),
+			Some(square) => SquareUtils::to_string(square),
 			None => "-".to_string(),
 		};
 

--- a/chess/src/board/impls/from.rs
+++ b/chess/src/board/impls/from.rs
@@ -1,13 +1,12 @@
 use bitboard::BitboardLSB;
 use castle_right::GetCastleRight;
-use square::GetSquare;
+use square::SquareUtils;
 
 use super::*;
 use super::{
 	color::{ColorConsts, Colors, GetColor},
 	file_rank::{Files, Ranks},
 	piece::{GetPiece, PieceConsts},
-	square::SquareConsts,
 };
 
 impl From<&str> for Board {
@@ -24,7 +23,7 @@ impl From<(&str, Arc<HashTable>)> for Board {
 			en_passant: None,
 			castle_rights: CastleRight::default(),
 
-			piece_list: [Piece::NONE; usize::SQUARE_SIZE],
+			piece_list: [Piece::NONE; SquareUtils::SIZE],
 			occupancy: Bitboard::default(),
 			occupancy_color: [Bitboard::default(); usize::COLOR_SIZE],
 
@@ -112,7 +111,7 @@ impl BoardBuilder {
 					board.add_piece(
 						Piece::get_piece(ch),
 						Color::get_color(ch.is_uppercase()),
-						Square::get_square((file, rank)),
+						SquareUtils::from_location(file, rank),
 					);
 					file += 1;
 				}
@@ -138,7 +137,7 @@ impl BoardBuilder {
 
 	fn set_en_passant(board: &mut Board, en_passant: &str) {
 		if en_passant != "-" {
-			board.en_passant = Some(Square::get_square(en_passant));
+			board.en_passant = Some(SquareUtils::parse(en_passant));
 		}
 	}
 }

--- a/chess/src/board/pieces.rs
+++ b/chess/src/board/pieces.rs
@@ -1,9 +1,9 @@
 use super::{
 	bitboard::BitboardString, color::ColorConsts, file_rank::FileRankConsts, piece::PieceConsts,
-	square::SquareConsts, Bitboard, Color, Piece,
+	square::SquareUtils, Bitboard, Color, Piece,
 };
 
-pub type PieceList = [Piece; usize::SQUARE_SIZE];
+pub type PieceList = [Piece; SquareUtils::SIZE];
 pub type BitboardPieces = [[Bitboard; usize::PIECE_SIZE]; usize::COLOR_SIZE];
 
 pub trait PrintBitboards {

--- a/chess/src/board/square.rs
+++ b/chess/src/board/square.rs
@@ -5,94 +5,86 @@ use super::{
 
 pub type Square = usize;
 
-pub trait Squares {
-	const A1: Square = 0;
-	const B1: Square = 1;
-	const C1: Square = 2;
-	const D1: Square = 3;
-	const E1: Square = 4;
-	const F1: Square = 5;
-	const G1: Square = 6;
-	const H1: Square = 7;
-	const A2: Square = 8;
-	const B2: Square = 9;
-	const C2: Square = 10;
-	const D2: Square = 11;
-	const E2: Square = 12;
-	const F2: Square = 13;
-	const G2: Square = 14;
-	const H2: Square = 15;
-	const A3: Square = 16;
-	const B3: Square = 17;
-	const C3: Square = 18;
-	const D3: Square = 19;
-	const E3: Square = 20;
-	const F3: Square = 21;
-	const G3: Square = 22;
-	const H3: Square = 23;
-	const A4: Square = 24;
-	const B4: Square = 25;
-	const C4: Square = 26;
-	const D4: Square = 27;
-	const E4: Square = 28;
-	const F4: Square = 29;
-	const G4: Square = 30;
-	const H4: Square = 31;
-	const A5: Square = 32;
-	const B5: Square = 33;
-	const C5: Square = 34;
-	const D5: Square = 35;
-	const E5: Square = 36;
-	const F5: Square = 37;
-	const G5: Square = 38;
-	const H5: Square = 39;
-	const A6: Square = 40;
-	const B6: Square = 41;
-	const C6: Square = 42;
-	const D6: Square = 43;
-	const E6: Square = 44;
-	const F6: Square = 45;
-	const G6: Square = 46;
-	const H6: Square = 47;
-	const A7: Square = 48;
-	const B7: Square = 49;
-	const C7: Square = 50;
-	const D7: Square = 51;
-	const E7: Square = 52;
-	const F7: Square = 53;
-	const G7: Square = 54;
-	const H7: Square = 55;
-	const A8: Square = 56;
-	const B8: Square = 57;
-	const C8: Square = 58;
-	const D8: Square = 59;
-	const E8: Square = 60;
-	const F8: Square = 61;
-	const G8: Square = 62;
-	const H8: Square = 63;
+pub struct SquareUtils;
+
+impl SquareUtils {
+	pub const SIZE: usize = 64;
+	pub const RANGE: std::ops::Range<Square> = 0..Self::SIZE;
 }
 
-pub trait SquareConsts {
-	const SQUARE_SIZE: usize = 64;
-	const SQUARE_RANGE: std::ops::Range<Square> = 0..Self::SQUARE_SIZE;
+impl SquareUtils {
+	pub const A1: Square = 0;
+	pub const B1: Square = 1;
+	pub const C1: Square = 2;
+	pub const D1: Square = 3;
+	pub const E1: Square = 4;
+	pub const F1: Square = 5;
+	pub const G1: Square = 6;
+	pub const H1: Square = 7;
+	pub const A2: Square = 8;
+	pub const B2: Square = 9;
+	pub const C2: Square = 10;
+	pub const D2: Square = 11;
+	pub const E2: Square = 12;
+	pub const F2: Square = 13;
+	pub const G2: Square = 14;
+	pub const H2: Square = 15;
+	pub const A3: Square = 16;
+	pub const B3: Square = 17;
+	pub const C3: Square = 18;
+	pub const D3: Square = 19;
+	pub const E3: Square = 20;
+	pub const F3: Square = 21;
+	pub const G3: Square = 22;
+	pub const H3: Square = 23;
+	pub const A4: Square = 24;
+	pub const B4: Square = 25;
+	pub const C4: Square = 26;
+	pub const D4: Square = 27;
+	pub const E4: Square = 28;
+	pub const F4: Square = 29;
+	pub const G4: Square = 30;
+	pub const H4: Square = 31;
+	pub const A5: Square = 32;
+	pub const B5: Square = 33;
+	pub const C5: Square = 34;
+	pub const D5: Square = 35;
+	pub const E5: Square = 36;
+	pub const F5: Square = 37;
+	pub const G5: Square = 38;
+	pub const H5: Square = 39;
+	pub const A6: Square = 40;
+	pub const B6: Square = 41;
+	pub const C6: Square = 42;
+	pub const D6: Square = 43;
+	pub const E6: Square = 44;
+	pub const F6: Square = 45;
+	pub const G6: Square = 46;
+	pub const H6: Square = 47;
+	pub const A7: Square = 48;
+	pub const B7: Square = 49;
+	pub const C7: Square = 50;
+	pub const D7: Square = 51;
+	pub const E7: Square = 52;
+	pub const F7: Square = 53;
+	pub const G7: Square = 54;
+	pub const H7: Square = 55;
+	pub const A8: Square = 56;
+	pub const B8: Square = 57;
+	pub const C8: Square = 58;
+	pub const D8: Square = 59;
+	pub const E8: Square = 60;
+	pub const F8: Square = 61;
+	pub const G8: Square = 62;
+	pub const H8: Square = 63;
 }
 
-impl Squares for Square {}
-impl SquareConsts for Square {}
-
-pub trait GetSquare<T> {
-	fn get_square(value: T) -> Self;
-}
-
-impl GetSquare<(File, Rank)> for Square {
-	#[inline(always)]
-	fn get_square((file, rank): (File, Rank)) -> Self {
-		(rank * 8 + file) as Self
+impl SquareUtils {
+	pub fn from_location(file: File, rank: Rank) -> Square {
+		(rank * 8 + file) as Square
 	}
-}
 
-impl GetSquare<&str> for Square {
-	fn get_square(value: &str) -> Self {
+	pub fn parse(value: &str) -> Square {
 		let chars = value.chars().collect::<Vec<char>>();
 
 		match (chars.first(), chars.get(1)) {
@@ -100,33 +92,18 @@ impl GetSquare<&str> for Square {
 				let file = File::get_file(*file);
 				let rank = Rank::get_rank(*rank);
 
-				(rank * 8 + file) as Self
+				rank * 8 + file
 			}
 			_ => panic!("Invalid square: {}", value),
 		}
 	}
-}
 
-pub trait SquareLocation {
-	fn location(&self) -> (File, Rank);
-}
-
-impl SquareLocation for Square {
-	#[inline(always)]
-	fn location(&self) -> (File, Rank) {
-		((*self % 8) as File, (*self / 8) as Rank)
+	pub fn location(square: Square) -> (File, Rank) {
+		(square % 8, square / 8)
 	}
-}
 
-pub trait SquareString {
-	fn square_string(&self) -> String;
-}
-
-impl SquareString for Square {
-	#[inline(always)]
-	fn square_string(&self) -> String {
-		let file = (*self % 8) as File;
-		let rank = (*self / 8) as Rank;
+	pub fn to_string(square: Square) -> String {
+		let (file, rank) = Self::location(square);
 
 		format!("{}{}", file.file_string(), rank.rank_string())
 	}

--- a/chess/src/board/zobrist.rs
+++ b/chess/src/board/zobrist.rs
@@ -1,14 +1,14 @@
 use super::{
-	castle_right::CastleRightConsts, color::ColorConsts, piece::PieceConsts, square::SquareConsts,
+	castle_right::CastleRightConsts, color::ColorConsts, piece::PieceConsts, square::SquareUtils,
 	CastleRight, Color, Piece, Square,
 };
 
 use rand::Rng;
 
-type PieceTable = [[[ZobristHash; Square::SQUARE_SIZE]; Piece::PIECE_SIZE]; Color::COLOR_SIZE];
+type PieceTable = [[[ZobristHash; SquareUtils::SIZE]; Piece::PIECE_SIZE]; Color::COLOR_SIZE];
 type ColorTable = [ZobristHash; Color::COLOR_SIZE];
 type CastleTable = [ZobristHash; CastleRight::CASTLE_RIGHT_SIZE];
-type EnPassantTable = [ZobristHash; Square::SQUARE_SIZE];
+type EnPassantTable = [ZobristHash; SquareUtils::SIZE];
 
 pub(crate) type ZobristHash = u64;
 
@@ -25,10 +25,10 @@ impl Default for HashTable {
 		let mut random = rand::thread_rng();
 
 		let mut hash_table = Self {
-			pieces: [[[0; Square::SQUARE_SIZE]; Piece::PIECE_SIZE]; Color::COLOR_SIZE],
+			pieces: [[[0; SquareUtils::SIZE]; Piece::PIECE_SIZE]; Color::COLOR_SIZE],
 			colors: [0; Color::COLOR_SIZE],
 			castles: [0; CastleRight::CASTLE_RIGHT_SIZE],
-			en_passant: [0; Square::SQUARE_SIZE],
+			en_passant: [0; SquareUtils::SIZE],
 		};
 
 		hash_table.pieces.iter_mut().for_each(|color| {

--- a/chess/src/move_gen/defs.rs
+++ b/chess/src/move_gen/defs.rs
@@ -1,8 +1,8 @@
 use super::Magic;
-use crate::board::{square::SquareConsts, Bitboard};
+use crate::board::{square::SquareUtils, Bitboard};
 
-pub type PieceMagics = [Magic; usize::SQUARE_SIZE];
-pub type PieceMoves = [Bitboard; usize::SQUARE_SIZE];
+pub type PieceMagics = [Magic; SquareUtils::SIZE];
+pub type PieceMoves = [Bitboard; SquareUtils::SIZE];
 pub type BlockerTable = Vec<Bitboard>;
 pub type AttackTable = Vec<Bitboard>;
 

--- a/chess/src/move_gen/direction.rs
+++ b/chess/src/move_gen/direction.rs
@@ -1,6 +1,6 @@
 use crate::board::{
 	file_rank::{Files, Ranks},
-	square::SquareLocation,
+	square::SquareUtils,
 	File, Rank, Square,
 };
 use std::ops;
@@ -19,7 +19,7 @@ pub enum Direction {
 
 impl PartialEq<Square> for Direction {
 	fn eq(&self, other: &Square) -> bool {
-		let (file, rank) = other.location();
+		let (file, rank) = SquareUtils::location(*other);
 
 		match self {
 			Self::North => rank == Rank::R8,

--- a/chess/src/move_gen/impls/init.rs
+++ b/chess/src/move_gen/impls/init.rs
@@ -4,20 +4,20 @@ use crate::board::{
 	color::{ColorConsts, Colors},
 	file_rank::{Files, Ranks},
 	piece::{PieceString, Pieces},
-	square::SquareConsts,
+	square::SquareUtils,
 	Bitboard, Color, File, Piece, Rank,
 };
 
 impl Default for MoveGen {
 	fn default() -> Self {
 		let mut move_gen = Self {
-			king: [Bitboard::default(); usize::SQUARE_SIZE],
+			king: [Bitboard::default(); SquareUtils::SIZE],
 			rooks: vec![Bitboard::default(); ROOK_TABLE_SIZE],
 			bishops: vec![Bitboard::default(); BISHOP_TABLE_SIZE],
-			rook_magics: [Magic::default(); usize::SQUARE_SIZE],
-			bishop_magics: [Magic::default(); usize::SQUARE_SIZE],
-			knight: [Bitboard::default(); usize::SQUARE_SIZE],
-			pawns: [[Bitboard::default(); usize::SQUARE_SIZE]; usize::COLOR_SIZE],
+			rook_magics: [Magic::default(); SquareUtils::SIZE],
+			bishop_magics: [Magic::default(); SquareUtils::SIZE],
+			knight: [Bitboard::default(); SquareUtils::SIZE],
+			pawns: [[Bitboard::default(); SquareUtils::SIZE]; usize::COLOR_SIZE],
 		};
 
 		move_gen.init_king();
@@ -32,7 +32,7 @@ impl Default for MoveGen {
 
 impl MoveGen {
 	fn init_king(&mut self) {
-		for square in usize::SQUARE_RANGE {
+		for square in SquareUtils::RANGE {
 			let bitboard = Bitboard::SQUARES[square];
 
 			self.king[square] |=
@@ -48,7 +48,7 @@ impl MoveGen {
 	}
 
 	fn init_knight(&mut self) {
-		for square in usize::SQUARE_RANGE {
+		for square in SquareUtils::RANGE {
 			let bitboard = Bitboard::SQUARES[square];
 
 			self.knight[square] |= (bitboard
@@ -88,7 +88,7 @@ impl MoveGen {
 	}
 
 	fn init_pawn(&mut self) {
-		for square in usize::SQUARE_RANGE {
+		for square in SquareUtils::RANGE {
 			let bitboard = Bitboard::SQUARES[square];
 
 			let white = (bitboard & !Bitboard::FILES[File::A]) << 7
@@ -112,7 +112,7 @@ impl MoveGen {
 
 		let mut offset = 0;
 
-		for square in usize::SQUARE_RANGE {
+		for square in SquareUtils::RANGE {
 			let mask = match is_rook {
 				true => MoveGen::rook_mask(square),
 				false => MoveGen::bishop_mask(square),

--- a/chess/src/move_gen/impls/mask.rs
+++ b/chess/src/move_gen/impls/mask.rs
@@ -2,14 +2,14 @@ use super::{AttackTable, BlockerTable, Direction, MoveGen};
 use crate::board::{
 	bitboard::{BitboardFiles, BitboardOccupied, BitboardRanks, BitboardSquares},
 	file_rank::{Files, Ranks},
-	square::SquareLocation,
+	square::SquareUtils,
 	Bitboard, File, Rank, Square,
 };
 
 impl MoveGen {
 	pub fn rook_mask(square: Square) -> Bitboard {
 		let edges = Self::edges(square);
-		let (file, rank) = square.location();
+		let (file, rank) = SquareUtils::location(square);
 
 		let mask = Bitboard::RANKS[rank] | Bitboard::FILES[file];
 
@@ -75,7 +75,7 @@ impl MoveGen {
 	}
 
 	fn edges(square: Square) -> Bitboard {
-		let (file, rank) = square.location();
+		let (file, rank) = SquareUtils::location(square);
 
 		let bitboard_file = Bitboard::FILES[file];
 		let bitboard_rank = Bitboard::RANKS[rank];

--- a/chess/src/move_gen/magic.rs
+++ b/chess/src/move_gen/magic.rs
@@ -1,6 +1,6 @@
 // Derived from https://github.com/mvanthoor/rustic
 
-use crate::board::{square::SquareConsts, Bitboard};
+use crate::board::{square::SquareUtils, Bitboard};
 
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Magic {
@@ -12,7 +12,7 @@ pub struct Magic {
 
 impl Magic {
 	#[rustfmt::skip]
-	pub const ROOK: [u64; usize::SQUARE_SIZE] = [
+	pub const ROOK: [u64; SquareUtils::SIZE] = [
 		0x008000108a204000, 0x0140012000441000, 0x0c80100080200508, 0x0180080006100080, 0x0080040058008042, 0x80801400800a0001, 0x0400021021018824, 0x04800080006a4100,
 		0x098080008c29c002, 0xf011004000810020, 0x0401001900402000, 0x010200102200401a, 0x0000800400080080, 0x03c0801200040180, 0x8004000430680326, 0x3108800080004900,
 		0x00004d0021008001, 0x1120004000403000, 0xa00a020020809042, 0x0010008008011380, 0x0201010004114800, 0x0001010008028400, 0x0210e40003288a10, 0x0027460001048344,
@@ -24,7 +24,7 @@ impl Magic {
 	];
 
 	#[rustfmt::skip]
-	pub const BISHOP: [u64; usize::SQUARE_SIZE] = [
+	pub const BISHOP: [u64; crate::board::square::SquareUtils::SIZE] = [
 		0x0842084131140100, 0x000810268ea10009, 0x004808010a200084, 0x4208218620880004, 0x0044050402204020, 0x2009041242881000, 0x0011880808041091, 0x0d12004242082010,
 		0x0000258428020401, 0x0000100401144201, 0x0082300400425001, 0x0208040c12800016, 0x14042e0210000000, 0x0022008220200404, 0x0814348410021000, 0x0004005404052810,
 		0x2219084022040420, 0x8022022004040480, 0x00a0442202040060, 0x0304000802542001, 0x4093800c00a00029, 0x0880200e10042000, 0x0203080584104602, 0x0000600202050409,
@@ -47,7 +47,7 @@ pub mod gen {
 	use std::time::Instant;
 
 	use super::super::{Magic, MoveGen, BISHOP_TABLE_SIZE, ROOK_TABLE_SIZE};
-	use crate::board::{piece::Pieces, square::SquareConsts, Bitboard, Piece, Square};
+	use crate::board::{piece::Pieces, square::SquareUtils, Bitboard, Piece};
 	use rand::Rng;
 
 	impl Magic {
@@ -70,7 +70,7 @@ pub mod gen {
 
 			println!("Generating magics for {piece}");
 
-			for square in Square::SQUARE_RANGE {
+			for square in SquareUtils::RANGE {
 				let mask = match is_rook {
 					true => MoveGen::rook_mask(square),
 					false => MoveGen::bishop_mask(square),

--- a/chess/src/move_gen/mod.rs
+++ b/chess/src/move_gen/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 		color::{ColorConsts, ColorString, Colors},
 		file_rank::Ranks,
 		piece::{PiecePromotions, Pieces},
-		square::{SquareConsts, Squares},
+		square::SquareUtils,
 		Bitboard, Board, CastleRight, Color, Piece, Rank, Square,
 	},
 	move_list::MoveList,
@@ -130,7 +130,7 @@ impl MoveGen {
 			_ => panic!("Invalid color: {}", color.color_string()),
 		};
 
-		let rotation_count = (usize::SQUARE_SIZE + direction) as u32;
+		let rotation_count = (SquareUtils::SIZE + direction) as u32;
 
 		let mut pieces = board.pieces[color][Piece::PAWN];
 
@@ -164,72 +164,74 @@ impl MoveGen {
 
 		if color == Color::WHITE && rights & CastleRight::WHITE > 0 {
 			if rights & CastleRight::WHITE_KING > 0 {
-				let blockers = Bitboard::SQUARES[Square::F1] | Bitboard::SQUARES[Square::G1];
+				let blockers =
+					Bitboard::SQUARES[SquareUtils::F1] | Bitboard::SQUARES[SquareUtils::G1];
 
 				if occupancy & blockers == 0
-					&& !self.square_attacked(board, opponent, Square::E1)
-					&& !self.square_attacked(board, opponent, Square::F1)
+					&& !self.square_attacked(board, opponent, SquareUtils::E1)
+					&& !self.square_attacked(board, opponent, SquareUtils::F1)
 				{
 					self.add_move(
 						board,
 						Piece::KING,
-						Square::E1,
-						Bitboard::SQUARES[Square::G1],
+						SquareUtils::E1,
+						Bitboard::SQUARES[SquareUtils::G1],
 						list,
 					);
 				}
 			}
 
 			if rights & CastleRight::WHITE_QUEEN > 0 {
-				let blockers = Bitboard::SQUARES[Square::D1]
-					| Bitboard::SQUARES[Square::C1]
-					| Bitboard::SQUARES[Square::B1];
+				let blockers = Bitboard::SQUARES[SquareUtils::D1]
+					| Bitboard::SQUARES[SquareUtils::C1]
+					| Bitboard::SQUARES[SquareUtils::B1];
 
 				if occupancy & blockers == 0
-					&& !self.square_attacked(board, opponent, Square::E1)
-					&& !self.square_attacked(board, opponent, Square::D1)
+					&& !self.square_attacked(board, opponent, SquareUtils::E1)
+					&& !self.square_attacked(board, opponent, SquareUtils::D1)
 				{
 					self.add_move(
 						board,
 						Piece::KING,
-						Square::E1,
-						Bitboard::SQUARES[Square::C1],
+						SquareUtils::E1,
+						Bitboard::SQUARES[SquareUtils::C1],
 						list,
 					);
 				}
 			}
 		} else if color == Color::BLACK && rights & CastleRight::BLACK > 0 {
 			if rights & CastleRight::BLACK_KING > 0 {
-				let blockers = Bitboard::SQUARES[Square::F8] | Bitboard::SQUARES[Square::G8];
+				let blockers =
+					Bitboard::SQUARES[SquareUtils::F8] | Bitboard::SQUARES[SquareUtils::G8];
 
 				if occupancy & blockers == 0
-					&& !self.square_attacked(board, opponent, Square::E8)
-					&& !self.square_attacked(board, opponent, Square::F8)
+					&& !self.square_attacked(board, opponent, SquareUtils::E8)
+					&& !self.square_attacked(board, opponent, SquareUtils::F8)
 				{
 					self.add_move(
 						board,
 						Piece::KING,
-						Square::E8,
-						Bitboard::SQUARES[Square::G8],
+						SquareUtils::E8,
+						Bitboard::SQUARES[SquareUtils::G8],
 						list,
 					);
 				}
 			}
 
 			if rights & CastleRight::BLACK_QUEEN > 0 {
-				let blockers = Bitboard::SQUARES[Square::D8]
-					| Bitboard::SQUARES[Square::C8]
-					| Bitboard::SQUARES[Square::B8];
+				let blockers = Bitboard::SQUARES[SquareUtils::D8]
+					| Bitboard::SQUARES[SquareUtils::C8]
+					| Bitboard::SQUARES[SquareUtils::B8];
 
 				if occupancy & blockers == 0
-					&& !self.square_attacked(board, opponent, Square::E8)
-					&& !self.square_attacked(board, opponent, Square::D8)
+					&& !self.square_attacked(board, opponent, SquareUtils::E8)
+					&& !self.square_attacked(board, opponent, SquareUtils::D8)
 				{
 					self.add_move(
 						board,
 						Piece::KING,
-						Square::E8,
-						Bitboard::SQUARES[Square::C8],
+						SquareUtils::E8,
+						Bitboard::SQUARES[SquareUtils::C8],
 						list,
 					);
 				}

--- a/chess/src/move_gen/piece_move.rs
+++ b/chess/src/move_gen/piece_move.rs
@@ -1,7 +1,7 @@
 // Marcel Vanthoor
 // https://github.com/mvanthoor/rustic
 
-use crate::board::{color::Colors, piece::PieceString, square::SquareString, Color, Piece, Square};
+use crate::board::{color::Colors, piece::PieceString, square::SquareUtils, Color, Piece, Square};
 use std::fmt::{self, Debug};
 
 #[derive(Copy, Clone, PartialEq)]
@@ -30,8 +30,8 @@ impl Debug for Move {
 		write!(
 			f,
 			"{}{} {} {} {} {en_passant} {two_step} {castling}",
-			from.square_string(),
-			to.square_string(),
+			SquareUtils::to_string(from),
+			SquareUtils::to_string(to),
 			piece.piece_string(Color::BOTH),
 			captured.piece_string(Color::BOTH),
 			promoted.piece_string(Color::BOTH),
@@ -44,7 +44,12 @@ impl fmt::Display for Move {
 		let from = self.from();
 		let to = self.to();
 
-		write!(f, "{}{}", from.square_string(), to.square_string())
+		write!(
+			f,
+			"{}{}",
+			SquareUtils::to_string(from),
+			SquareUtils::to_string(to)
+		)
 	}
 }
 

--- a/chess/src/playmove.rs
+++ b/chess/src/playmove.rs
@@ -4,8 +4,8 @@ use crate::{
 		castle_right::{CastleRightSquares, CastleRights},
 		color::Colors,
 		piece::Pieces,
-		square::{SquareString, Squares},
-		CastleRight, Color, Piece, Square,
+		square::SquareUtils,
+		CastleRight, Color, Piece,
 	},
 	history::OldState,
 	move_gen::Move,
@@ -74,23 +74,23 @@ impl Chess {
 
 			if m.castling() {
 				match to {
-					Square::G1 => {
-						board.remove_piece(Piece::ROOK, color, Square::H1);
-						board.add_piece(Piece::ROOK, color, Square::F1);
+					SquareUtils::G1 => {
+						board.remove_piece(Piece::ROOK, color, SquareUtils::H1);
+						board.add_piece(Piece::ROOK, color, SquareUtils::F1);
 					}
-					Square::C1 => {
-						board.remove_piece(Piece::ROOK, color, Square::A1);
-						board.add_piece(Piece::ROOK, color, Square::D1);
+					SquareUtils::C1 => {
+						board.remove_piece(Piece::ROOK, color, SquareUtils::A1);
+						board.add_piece(Piece::ROOK, color, SquareUtils::D1);
 					}
-					Square::G8 => {
-						board.remove_piece(Piece::ROOK, color, Square::H8);
-						board.add_piece(Piece::ROOK, color, Square::F8);
+					SquareUtils::G8 => {
+						board.remove_piece(Piece::ROOK, color, SquareUtils::H8);
+						board.add_piece(Piece::ROOK, color, SquareUtils::F8);
 					}
-					Square::C8 => {
-						board.remove_piece(Piece::ROOK, color, Square::A8);
-						board.add_piece(Piece::ROOK, color, Square::D8);
+					SquareUtils::C8 => {
+						board.remove_piece(Piece::ROOK, color, SquareUtils::A8);
+						board.add_piece(Piece::ROOK, color, SquareUtils::D8);
 					}
-					_ => panic!("Invalid castling move: {}", to.square_string()),
+					_ => panic!("Invalid castling move: {}", SquareUtils::to_string(to)),
 				}
 			}
 		}
@@ -141,23 +141,23 @@ impl Chess {
 
 				if m.castling() {
 					match to {
-						Square::G1 => {
-							board.remove_piece(Piece::ROOK, color, Square::F1);
-							board.add_piece(Piece::ROOK, color, Square::H1);
+						SquareUtils::G1 => {
+							board.remove_piece(Piece::ROOK, color, SquareUtils::F1);
+							board.add_piece(Piece::ROOK, color, SquareUtils::H1);
 						}
-						Square::C1 => {
-							board.remove_piece(Piece::ROOK, color, Square::D1);
-							board.add_piece(Piece::ROOK, color, Square::A1);
+						SquareUtils::C1 => {
+							board.remove_piece(Piece::ROOK, color, SquareUtils::D1);
+							board.add_piece(Piece::ROOK, color, SquareUtils::A1);
 						}
-						Square::G8 => {
-							board.remove_piece(Piece::ROOK, color, Square::F8);
-							board.add_piece(Piece::ROOK, color, Square::H8);
+						SquareUtils::G8 => {
+							board.remove_piece(Piece::ROOK, color, SquareUtils::F8);
+							board.add_piece(Piece::ROOK, color, SquareUtils::H8);
 						}
-						Square::C8 => {
-							board.remove_piece(Piece::ROOK, color, Square::D8);
-							board.add_piece(Piece::ROOK, color, Square::A8);
+						SquareUtils::C8 => {
+							board.remove_piece(Piece::ROOK, color, SquareUtils::D8);
+							board.add_piece(Piece::ROOK, color, SquareUtils::A8);
 						}
-						_ => panic!("Invalid castling move: {}", to.square_string()),
+						_ => panic!("Invalid castling move: {}", SquareUtils::to_string(to)),
 					}
 				}
 			} else {


### PR DESCRIPTION
This is to avoid importing many `Square` related **traits**