### PR TITLE
refator: file_rank to use `RankUtils` and `FileUtils` struct instead of **traits**

### DIFF
--- a/chess/src/board/bitboard.rs
+++ b/chess/src/board/bitboard.rs
@@ -1,10 +1,14 @@
-use super::{file_rank::FileRankConsts, square::SquareUtils, File, Rank, Square};
+use super::{
+	file_rank::{FileUtils, RankUtils},
+	square::SquareUtils,
+	Square,
+};
 
 pub type Bitboard = u64;
 
 pub trait BitboardFiles {
 	#[rustfmt::skip]
-	const FILES: [Bitboard; usize::FILE_RANK_SIZE] = [
+	const FILES: [Bitboard; FileUtils::SIZE] = [
 		0x0101010101010101, 0x0202020202020202, 0x0404040404040404, 0x0808080808080808,
 		0x1010101010101010, 0x2020202020202020, 0x4040404040404040, 0x8080808080808080,
 	];
@@ -12,7 +16,7 @@ pub trait BitboardFiles {
 
 pub trait BitboardRanks {
 	#[rustfmt::skip]
-	const RANKS: [Bitboard; usize::FILE_RANK_SIZE] = [
+	const RANKS: [Bitboard; RankUtils::SIZE] = [
 		0x00000000000000FF, 0x000000000000FF00, 0x0000000000FF0000, 0x00000000FF000000,
 		0x000000FF00000000, 0x0000FF0000000000, 0x00FF000000000000, 0xFF00000000000000,
 	];
@@ -82,8 +86,8 @@ impl BitboardString for Bitboard {
 	fn bitboard_string(&self) -> String {
 		let mut string = String::new();
 
-		for rank in Rank::FILE_RANK_RANGE.rev() {
-			for file in File::FILE_RANK_RANGE {
+		for rank in RankUtils::RANGE.rev() {
+			for file in FileUtils::RANGE {
 				let square = SquareUtils::from_location(file, rank);
 
 				string.push_str(match self.occupied(square) {

--- a/chess/src/board/file_rank.rs
+++ b/chess/src/board/file_rank.rs
@@ -1,63 +1,26 @@
 pub type File = usize;
 pub type Rank = usize;
 
-pub trait Files {
-	const A: File = 0;
-	const B: File = 1;
-	const C: File = 2;
-	const D: File = 3;
-	const E: File = 4;
-	const F: File = 5;
-	const G: File = 6;
-	const H: File = 7;
+pub struct RankUtils;
+
+impl RankUtils {
+	pub const SIZE: usize = 8;
+	pub const RANGE: std::ops::Range<usize> = 0..Self::SIZE;
 }
 
-pub trait Ranks {
-	const R1: Rank = 0;
-	const R2: Rank = 1;
-	const R3: Rank = 2;
-	const R4: Rank = 3;
-	const R5: Rank = 4;
-	const R6: Rank = 5;
-	const R7: Rank = 6;
-	const R8: Rank = 7;
+impl RankUtils {
+	pub const R1: Rank = 0;
+	pub const R2: Rank = 1;
+	pub const R3: Rank = 2;
+	pub const R4: Rank = 3;
+	pub const R5: Rank = 4;
+	pub const R6: Rank = 5;
+	pub const R7: Rank = 6;
+	pub const R8: Rank = 7;
 }
 
-pub trait FileRankConsts {
-	const FILE_RANK_SIZE: usize = 8;
-	const FILE_RANK_RANGE: std::ops::Range<usize> = 0..Self::FILE_RANK_SIZE;
-}
-
-impl Files for File {}
-impl Ranks for Rank {}
-impl FileRankConsts for usize {}
-
-pub trait GetFile<T> {
-	fn get_file(value: T) -> Self;
-}
-
-impl GetFile<char> for File {
-	fn get_file(value: char) -> Self {
-		match value {
-			'a' => Self::A,
-			'b' => Self::B,
-			'c' => Self::C,
-			'd' => Self::D,
-			'e' => Self::E,
-			'f' => Self::F,
-			'g' => Self::G,
-			'h' => Self::H,
-			_ => panic!("Invalid file: {}", value),
-		}
-	}
-}
-
-pub trait GetRank<T> {
-	fn get_rank(value: T) -> Self;
-}
-
-impl GetRank<char> for Rank {
-	fn get_rank(value: char) -> Self {
+impl RankUtils {
+	pub fn from_char(value: char) -> Rank {
 		match value {
 			'1' => Self::R1,
 			'2' => Self::R2,
@@ -70,46 +33,66 @@ impl GetRank<char> for Rank {
 			_ => panic!("Invalid rank: {}", value),
 		}
 	}
-}
 
-pub trait FileString {
-	fn file_string(&self) -> String;
-}
-
-impl FileString for File {
-	#[inline(always)]
-	fn file_string(&self) -> String {
-		String::from(match *self {
-			Self::A => "a",
-			Self::B => "b",
-			Self::C => "c",
-			Self::D => "d",
-			Self::E => "e",
-			Self::F => "f",
-			Self::G => "g",
-			Self::H => "h",
-			_ => panic!("Invalid file: {self}"),
-		})
+	pub fn to_char(value: Rank) -> char {
+		match value {
+			Self::R1 => '1',
+			Self::R2 => '2',
+			Self::R3 => '3',
+			Self::R4 => '4',
+			Self::R5 => '5',
+			Self::R6 => '6',
+			Self::R7 => '7',
+			Self::R8 => '8',
+			_ => panic!("Invalid rank: {}", value),
+		}
 	}
 }
 
-pub trait RankString {
-	fn rank_string(&self) -> String;
+pub struct FileUtils;
+
+impl FileUtils {
+	pub const SIZE: usize = RankUtils::SIZE;
+	pub const RANGE: std::ops::Range<usize> = RankUtils::RANGE;
 }
 
-impl RankString for Rank {
-	#[inline(always)]
-	fn rank_string(&self) -> String {
-		String::from(match *self {
-			Self::R1 => "1",
-			Self::R2 => "2",
-			Self::R3 => "3",
-			Self::R4 => "4",
-			Self::R5 => "5",
-			Self::R6 => "6",
-			Self::R7 => "7",
-			Self::R8 => "8",
-			_ => panic!("Invalid rank: {self}"),
-		})
+impl FileUtils {
+	pub const A: File = 0;
+	pub const B: File = 1;
+	pub const C: File = 2;
+	pub const D: File = 3;
+	pub const E: File = 4;
+	pub const F: File = 5;
+	pub const G: File = 6;
+	pub const H: File = 7;
+}
+
+impl FileUtils {
+	pub fn from_char(value: char) -> File {
+		match value {
+			'a' => Self::A,
+			'b' => Self::B,
+			'c' => Self::C,
+			'd' => Self::D,
+			'e' => Self::E,
+			'f' => Self::F,
+			'g' => Self::G,
+			'h' => Self::H,
+			_ => panic!("Invalid file: {}", value),
+		}
+	}
+
+	pub fn to_char(value: File) -> char {
+		match value {
+			Self::A => 'a',
+			Self::B => 'b',
+			Self::C => 'c',
+			Self::D => 'd',
+			Self::E => 'e',
+			Self::F => 'f',
+			Self::G => 'g',
+			Self::H => 'h',
+			_ => panic!("Invalid file: {}", value),
+		}
 	}
 }

--- a/chess/src/board/impls/display.rs
+++ b/chess/src/board/impls/display.rs
@@ -1,12 +1,11 @@
 use castle_right::CastleRightString;
-use file_rank::Ranks;
+use file_rank::{FileUtils, RankUtils};
 use square::SquareUtils;
 
 use super::*;
 use super::{
 	bitboard::BitboardOccupied,
 	color::{ColorConsts, ColorString},
-	file_rank::FileRankConsts,
 	piece::PieceString,
 };
 use std::fmt;
@@ -37,10 +36,10 @@ impl Board {
 	fn board_string(&self) -> String {
 		let mut board = String::from("   +---+---+---+---+---+---+---+---+\n");
 
-		for rank in usize::FILE_RANK_RANGE.rev() {
+		for rank in RankUtils::RANGE.rev() {
 			board += &format!(" {rank} ");
 
-			for file in usize::FILE_RANK_RANGE {
+			for file in FileUtils::RANGE {
 				let piece = match self.get_piece(SquareUtils::from_location(file, rank)) {
 					Some((piece, color)) => piece.piece_string(color),
 					None => " ".to_string(),
@@ -58,10 +57,10 @@ impl Board {
 	fn fen_string(&self) -> String {
 		let mut pieces = String::new();
 
-		for rank in usize::FILE_RANK_RANGE.rev() {
+		for rank in RankUtils::RANGE.rev() {
 			let mut empty = 0;
 
-			for file in usize::FILE_RANK_RANGE {
+			for file in FileUtils::RANGE {
 				let square = SquareUtils::from_location(file, rank);
 
 				match self.get_piece(square) {
@@ -81,7 +80,7 @@ impl Board {
 				pieces.push_str(&empty.to_string());
 			}
 
-			if rank > Rank::R1 {
+			if rank > RankUtils::R1 {
 				pieces += "/";
 			}
 		}

--- a/chess/src/board/impls/from.rs
+++ b/chess/src/board/impls/from.rs
@@ -1,11 +1,11 @@
 use bitboard::BitboardLSB;
 use castle_right::GetCastleRight;
+use file_rank::{FileUtils, RankUtils};
 use square::SquareUtils;
 
 use super::*;
 use super::{
 	color::{ColorConsts, Colors, GetColor},
-	file_rank::{Files, Ranks},
 	piece::{GetPiece, PieceConsts},
 };
 
@@ -93,14 +93,14 @@ struct BoardBuilder;
 
 impl BoardBuilder {
 	fn set_pieces(board: &mut Board, pieces: &str) {
-		let mut rank = Rank::R8;
-		let mut file = File::A;
+		let mut rank = RankUtils::R8;
+		let mut file = FileUtils::A;
 
 		for ch in pieces.chars() {
 			match ch {
 				'/' => {
 					rank -= 1;
-					file = File::A;
+					file = FileUtils::A;
 				}
 				'1'..='8' => {
 					for _ in 0..ch.to_digit(10).unwrap() {

--- a/chess/src/board/pieces.rs
+++ b/chess/src/board/pieces.rs
@@ -1,6 +1,8 @@
+use crate::board::file_rank::RankUtils;
+
 use super::{
-	bitboard::BitboardString, color::ColorConsts, file_rank::FileRankConsts, piece::PieceConsts,
-	square::SquareUtils, Bitboard, Color, Piece,
+	bitboard::BitboardString, color::ColorConsts, piece::PieceConsts, square::SquareUtils,
+	Bitboard, Color, Piece,
 };
 
 pub type PieceList = [Piece; SquareUtils::SIZE];
@@ -24,7 +26,7 @@ impl PrintBitboards for BitboardPieces {
 				"King", "Queen", "Rook", "Bishop", "Knight", "Pawn"
 			);
 
-			for rank in usize::FILE_RANK_RANGE.rev() {
+			for rank in RankUtils::RANGE.rev() {
 				let mut combined_line = String::new();
 
 				for (piece, line) in lines.iter().enumerate() {

--- a/chess/src/board/square.rs
+++ b/chess/src/board/square.rs
@@ -1,5 +1,5 @@
 use super::{
-	file_rank::{FileString, GetFile, GetRank, RankString},
+	file_rank::{FileUtils, RankUtils},
 	File, Rank,
 };
 
@@ -89,8 +89,8 @@ impl SquareUtils {
 
 		match (chars.first(), chars.get(1)) {
 			(Some(file), Some(rank)) => {
-				let file = File::get_file(*file);
-				let rank = Rank::get_rank(*rank);
+				let file = FileUtils::from_char(*file);
+				let rank = FileUtils::from_char(*rank);
 
 				rank * 8 + file
 			}
@@ -105,6 +105,6 @@ impl SquareUtils {
 	pub fn to_string(square: Square) -> String {
 		let (file, rank) = Self::location(square);
 
-		format!("{}{}", file.file_string(), rank.rank_string())
+		format!("{}{}", FileUtils::to_char(file), RankUtils::to_char(rank))
 	}
 }

--- a/chess/src/move_gen/direction.rs
+++ b/chess/src/move_gen/direction.rs
@@ -1,7 +1,7 @@
 use crate::board::{
-	file_rank::{Files, Ranks},
+	file_rank::{FileUtils, RankUtils},
 	square::SquareUtils,
-	File, Rank, Square,
+	Square,
 };
 use std::ops;
 
@@ -22,14 +22,14 @@ impl PartialEq<Square> for Direction {
 		let (file, rank) = SquareUtils::location(*other);
 
 		match self {
-			Self::North => rank == Rank::R8,
-			Self::South => rank == Rank::R1,
-			Self::East => file == File::H,
-			Self::West => file == File::A,
-			Self::NorthEast => rank == Rank::R8 || file == File::H,
-			Self::NorthWest => rank == Rank::R8 || file == File::A,
-			Self::SouthEast => rank == Rank::R1 || file == File::H,
-			Self::SouthWest => rank == Rank::R1 || file == File::A,
+			Self::North => rank == RankUtils::R8,
+			Self::South => rank == RankUtils::R1,
+			Self::East => file == FileUtils::H,
+			Self::West => file == FileUtils::A,
+			Self::NorthEast => rank == RankUtils::R8 || file == FileUtils::H,
+			Self::NorthWest => rank == RankUtils::R8 || file == FileUtils::A,
+			Self::SouthEast => rank == RankUtils::R1 || file == FileUtils::H,
+			Self::SouthWest => rank == RankUtils::R1 || file == FileUtils::A,
 		}
 	}
 }

--- a/chess/src/move_gen/impls/init.rs
+++ b/chess/src/move_gen/impls/init.rs
@@ -2,10 +2,10 @@ use super::{Magic, MoveGen, BISHOP_TABLE_SIZE, ROOK_TABLE_SIZE};
 use crate::board::{
 	bitboard::{BitboardFiles, BitboardRanks, BitboardSquares},
 	color::{ColorConsts, Colors},
-	file_rank::{Files, Ranks},
+	file_rank::{FileUtils, RankUtils},
 	piece::{PieceString, Pieces},
 	square::SquareUtils,
-	Bitboard, Color, File, Piece, Rank,
+	Bitboard, Color, Piece,
 };
 
 impl Default for MoveGen {
@@ -36,14 +36,14 @@ impl MoveGen {
 			let bitboard = Bitboard::SQUARES[square];
 
 			self.king[square] |=
-				(bitboard & !Bitboard::FILES[File::A] & !Bitboard::RANKS[Rank::R8]) << 7
-					| (bitboard & !Bitboard::RANKS[Rank::R8]) << 8
-					| (bitboard & !Bitboard::RANKS[Rank::R8] & !Bitboard::FILES[File::H]) << 9
-					| (bitboard & !Bitboard::FILES[File::H]) << 1
-					| (bitboard & !Bitboard::RANKS[Rank::R1] & !Bitboard::FILES[File::H]) >> 7
-					| (bitboard & !Bitboard::RANKS[Rank::R1]) >> 8
-					| (bitboard & !Bitboard::RANKS[Rank::R1] & !Bitboard::FILES[File::A]) >> 9
-					| (bitboard & !Bitboard::FILES[File::A]) >> 1;
+				(bitboard & !Bitboard::FILES[FileUtils::A] & !Bitboard::RANKS[RankUtils::R8]) << 7
+					| (bitboard & !Bitboard::RANKS[RankUtils::R8]) << 8
+					| (bitboard & !Bitboard::RANKS[RankUtils::R8] & !Bitboard::FILES[FileUtils::H])
+						<< 9 | (bitboard & !Bitboard::FILES[FileUtils::H]) << 1
+					| (bitboard & !Bitboard::RANKS[RankUtils::R1] & !Bitboard::FILES[FileUtils::H])
+						>> 7 | (bitboard & !Bitboard::RANKS[RankUtils::R1]) >> 8
+					| (bitboard & !Bitboard::RANKS[RankUtils::R1] & !Bitboard::FILES[FileUtils::A])
+						>> 9 | (bitboard & !Bitboard::FILES[FileUtils::A]) >> 1;
 		}
 	}
 
@@ -52,37 +52,37 @@ impl MoveGen {
 			let bitboard = Bitboard::SQUARES[square];
 
 			self.knight[square] |= (bitboard
-				& !Bitboard::RANKS[Rank::R8]
-				& !Bitboard::RANKS[Rank::R7]
-				& !Bitboard::FILES[File::A])
+				& !Bitboard::RANKS[RankUtils::R8]
+				& !Bitboard::RANKS[RankUtils::R7]
+				& !Bitboard::FILES[FileUtils::A])
 				<< 15 | (bitboard
-				& !Bitboard::RANKS[Rank::R8]
-				& !Bitboard::RANKS[Rank::R7]
-				& !Bitboard::FILES[File::H])
+				& !Bitboard::RANKS[RankUtils::R8]
+				& !Bitboard::RANKS[RankUtils::R7]
+				& !Bitboard::FILES[FileUtils::H])
 				<< 17 | (bitboard
-				& !Bitboard::RANKS[Rank::R8]
-				& !Bitboard::FILES[File::A]
-				& !Bitboard::FILES[File::B])
+				& !Bitboard::RANKS[RankUtils::R8]
+				& !Bitboard::FILES[FileUtils::A]
+				& !Bitboard::FILES[FileUtils::B])
 				<< 6 | (bitboard
-				& !Bitboard::RANKS[Rank::R8]
-				& !Bitboard::FILES[File::G]
-				& !Bitboard::FILES[File::H])
+				& !Bitboard::RANKS[RankUtils::R8]
+				& !Bitboard::FILES[FileUtils::G]
+				& !Bitboard::FILES[FileUtils::H])
 				<< 10 | (bitboard
-				& !Bitboard::RANKS[Rank::R1]
-				& !Bitboard::RANKS[Rank::R2]
-				& !Bitboard::FILES[File::A])
+				& !Bitboard::RANKS[RankUtils::R1]
+				& !Bitboard::RANKS[RankUtils::R2]
+				& !Bitboard::FILES[FileUtils::A])
 				>> 17 | (bitboard
-				& !Bitboard::RANKS[Rank::R1]
-				& !Bitboard::RANKS[Rank::R2]
-				& !Bitboard::FILES[File::H])
+				& !Bitboard::RANKS[RankUtils::R1]
+				& !Bitboard::RANKS[RankUtils::R2]
+				& !Bitboard::FILES[FileUtils::H])
 				>> 15 | (bitboard
-				& !Bitboard::RANKS[Rank::R1]
-				& !Bitboard::FILES[File::A]
-				& !Bitboard::FILES[File::B])
+				& !Bitboard::RANKS[RankUtils::R1]
+				& !Bitboard::FILES[FileUtils::A]
+				& !Bitboard::FILES[FileUtils::B])
 				>> 10 | (bitboard
-				& !Bitboard::RANKS[Rank::R1]
-				& !Bitboard::FILES[File::G]
-				& !Bitboard::FILES[File::H])
+				& !Bitboard::RANKS[RankUtils::R1]
+				& !Bitboard::FILES[FileUtils::G]
+				& !Bitboard::FILES[FileUtils::H])
 				>> 6;
 		}
 	}
@@ -91,10 +91,10 @@ impl MoveGen {
 		for square in SquareUtils::RANGE {
 			let bitboard = Bitboard::SQUARES[square];
 
-			let white = (bitboard & !Bitboard::FILES[File::A]) << 7
-				| (bitboard & !Bitboard::FILES[File::H]) << 9;
-			let black = (bitboard & !Bitboard::FILES[File::H]) >> 7
-				| (bitboard & !Bitboard::FILES[File::A]) >> 9;
+			let white = (bitboard & !Bitboard::FILES[FileUtils::A]) << 7
+				| (bitboard & !Bitboard::FILES[FileUtils::H]) << 9;
+			let black = (bitboard & !Bitboard::FILES[FileUtils::H]) >> 7
+				| (bitboard & !Bitboard::FILES[FileUtils::A]) >> 9;
 
 			self.pawns[Color::WHITE][square] = white;
 			self.pawns[Color::BLACK][square] = black;

--- a/chess/src/move_gen/impls/mask.rs
+++ b/chess/src/move_gen/impls/mask.rs
@@ -1,9 +1,9 @@
 use super::{AttackTable, BlockerTable, Direction, MoveGen};
 use crate::board::{
 	bitboard::{BitboardFiles, BitboardOccupied, BitboardRanks, BitboardSquares},
-	file_rank::{Files, Ranks},
+	file_rank::{FileUtils, RankUtils},
 	square::SquareUtils,
-	Bitboard, File, Rank, Square,
+	Bitboard, Square,
 };
 
 impl MoveGen {
@@ -80,10 +80,10 @@ impl MoveGen {
 		let bitboard_file = Bitboard::FILES[file];
 		let bitboard_rank = Bitboard::RANKS[rank];
 
-		(!bitboard_file & Bitboard::FILES[File::A])
-			| (!bitboard_file & Bitboard::FILES[File::H])
-			| (!bitboard_rank & Bitboard::RANKS[Rank::R1])
-			| (!bitboard_rank & Bitboard::RANKS[Rank::R8])
+		(!bitboard_file & Bitboard::FILES[FileUtils::A])
+			| (!bitboard_file & Bitboard::FILES[FileUtils::H])
+			| (!bitboard_rank & Bitboard::RANKS[RankUtils::R1])
+			| (!bitboard_rank & Bitboard::RANKS[RankUtils::R8])
 	}
 
 	fn ray(bitboard: Bitboard, mut square: Square, direction: Direction) -> Bitboard {

--- a/chess/src/move_gen/mod.rs
+++ b/chess/src/move_gen/mod.rs
@@ -10,10 +10,10 @@ use crate::{
 		bitboard::{BitboardLSB, BitboardOccupied, BitboardRanks, BitboardSquares},
 		castle_right::CastleRights,
 		color::{ColorConsts, ColorString, Colors},
-		file_rank::Ranks,
+		file_rank::RankUtils,
 		piece::{PiecePromotions, Pieces},
 		square::SquareUtils,
-		Bitboard, Board, CastleRight, Color, Piece, Rank, Square,
+		Bitboard, Board, CastleRight, Color, Piece, Square,
 	},
 	move_list::MoveList,
 };
@@ -119,8 +119,8 @@ impl MoveGen {
 		let empty = !board.occupancy;
 
 		let fourth = match color {
-			Color::WHITE => Rank::R4,
-			Color::BLACK => Rank::R5,
+			Color::WHITE => RankUtils::R4,
+			Color::BLACK => RankUtils::R5,
 			_ => panic!("Invalid color: {}", color.color_string()),
 		};
 
@@ -255,8 +255,8 @@ impl MoveGen {
 		let is_pawn = Piece::PAWN == piece;
 
 		let promotion_rank = match color {
-			Color::WHITE => Rank::R8,
-			Color::BLACK => Rank::R1,
+			Color::WHITE => RankUtils::R8,
+			Color::BLACK => RankUtils::R1,
 			_ => panic!("Invalid color: {}", color.color_string()),
 		};
 


### PR DESCRIPTION
This is prevent form importing multiple **traits** related to `file_rank`.