### PR TITLE
refactor: bitboard to use `BitboardUtils` struct instead of traits

### DIFF
--- a/chess/src/board/bitboard.rs
+++ b/chess/src/board/bitboard.rs
@@ -6,25 +6,25 @@ use super::{
 
 pub type Bitboard = u64;
 
-pub trait BitboardFiles {
+pub struct BitboardUtils;
+
+impl BitboardUtils {
+	pub const EMPTY: Bitboard = 0;
+
 	#[rustfmt::skip]
-	const FILES: [Bitboard; FileUtils::SIZE] = [
+	pub const FILES: [Bitboard; FileUtils::SIZE] = [
 		0x0101010101010101, 0x0202020202020202, 0x0404040404040404, 0x0808080808080808,
 		0x1010101010101010, 0x2020202020202020, 0x4040404040404040, 0x8080808080808080,
 	];
-}
 
-pub trait BitboardRanks {
-	#[rustfmt::skip]
-	const RANKS: [Bitboard; RankUtils::SIZE] = [
+    #[rustfmt::skip]
+	pub const RANKS: [Bitboard; RankUtils::SIZE] = [
 		0x00000000000000FF, 0x000000000000FF00, 0x0000000000FF0000, 0x00000000FF000000,
 		0x000000FF00000000, 0x0000FF0000000000, 0x00FF000000000000, 0xFF00000000000000,
 	];
-}
 
-pub trait BitboardSquares {
-	#[rustfmt::skip]
-	const SQUARES: [Bitboard; SquareUtils::SIZE] = [
+    #[rustfmt::skip]
+	pub const SQUARES: [Bitboard; SquareUtils::SIZE] = [
 		0x0000000000000001, 0x0000000000000002, 0x0000000000000004, 0x0000000000000008,
 		0x0000000000000010, 0x0000000000000020, 0x0000000000000040, 0x0000000000000080,
 		0x0000000000000100, 0x0000000000000200, 0x0000000000000400, 0x0000000000000800,
@@ -44,53 +44,32 @@ pub trait BitboardSquares {
 	];
 }
 
-impl BitboardFiles for Bitboard {}
-impl BitboardRanks for Bitboard {}
-impl BitboardSquares for Bitboard {}
-
-pub trait BitboardLSB {
-	fn pop_lsb(&mut self) -> Square;
-	fn lsb(&self) -> Square;
-}
-
-impl BitboardLSB for Bitboard {
+impl BitboardUtils {
 	#[inline(always)]
-	fn pop_lsb(&mut self) -> Square {
-		let lsb = self.lsb();
-		*self &= *self - 1;
+	pub fn pop_lsb(bitboard: &mut Bitboard) -> Square {
+		let lsb = bitboard.trailing_zeros() as Square;
+		*bitboard &= *bitboard - 1;
 		lsb
 	}
 
 	#[inline(always)]
-	fn lsb(&self) -> Square {
-		self.trailing_zeros() as Square
+	pub fn lsb(bitboard: Bitboard) -> Square {
+		bitboard.trailing_zeros() as Square
 	}
-}
 
-pub trait BitboardOccupied<T: std::ops::BitAnd> {
-	fn occupied(&self, square: T) -> bool;
-}
-
-impl BitboardOccupied<Square> for Bitboard {
 	#[inline(always)]
-	fn occupied(&self, square: Square) -> bool {
-		self & Self::SQUARES[square] > 0
+	pub fn occupied(bitboard: Bitboard, square: Square) -> bool {
+		bitboard & Self::SQUARES[square] > 0
 	}
-}
 
-pub trait BitboardString {
-	fn bitboard_string(&self) -> String;
-}
-
-impl BitboardString for Bitboard {
-	fn bitboard_string(&self) -> String {
+	pub fn to_string(bitboard: Bitboard) -> String {
 		let mut string = String::new();
 
 		for rank in RankUtils::RANGE.rev() {
 			for file in FileUtils::RANGE {
 				let square = SquareUtils::from_location(file, rank);
 
-				string.push_str(match self.occupied(square) {
+				string.push_str(match Self::occupied(bitboard, square) {
 					true => "1 ",
 					false => "0 ",
 				});

--- a/chess/src/board/impls/display.rs
+++ b/chess/src/board/impls/display.rs
@@ -4,7 +4,6 @@ use square::SquareUtils;
 
 use super::*;
 use super::{
-	bitboard::BitboardOccupied,
 	color::{ColorConsts, ColorString},
 	piece::PieceString,
 };
@@ -24,7 +23,7 @@ impl Board {
 			None
 		} else {
 			for color in Color::COLOR_RANGE {
-				if self.pieces[color][piece].occupied(square) {
+				if BitboardUtils::occupied(self.pieces[color][piece], square) {
 					return Some((piece, color));
 				}
 			}

--- a/chess/src/board/impls/from.rs
+++ b/chess/src/board/impls/from.rs
@@ -1,4 +1,4 @@
-use bitboard::BitboardLSB;
+use bitboard::BitboardUtils;
 use castle_right::GetCastleRight;
 use file_rank::{FileUtils, RankUtils};
 use square::SquareUtils;
@@ -18,14 +18,14 @@ impl From<&str> for Board {
 impl From<(&str, Arc<HashTable>)> for Board {
 	fn from(value: (&str, Arc<HashTable>)) -> Self {
 		let mut board = Self {
-			pieces: [[Bitboard::default(); usize::PIECE_SIZE]; usize::COLOR_SIZE],
+			pieces: [[BitboardUtils::EMPTY; usize::PIECE_SIZE]; usize::COLOR_SIZE],
 			color: Color::WHITE,
 			en_passant: None,
 			castle_rights: CastleRight::default(),
 
 			piece_list: [Piece::NONE; SquareUtils::SIZE],
-			occupancy: Bitboard::default(),
-			occupancy_color: [Bitboard::default(); usize::COLOR_SIZE],
+			occupancy: BitboardUtils::EMPTY,
+			occupancy_color: [BitboardUtils::EMPTY; usize::COLOR_SIZE],
 
 			halfmove_clock: 0,
 			fullmove_number: 1,
@@ -68,13 +68,13 @@ impl Board {
 			let mut black_pieces = *black;
 
 			while white_pieces > 0 {
-				let square = white_pieces.pop_lsb();
+				let square = BitboardUtils::pop_lsb(&mut white_pieces);
 
 				self.hash ^= self.hash_table.piece(piece, Color::WHITE, square);
 			}
 
 			while black_pieces > 0 {
-				let square = black_pieces.pop_lsb();
+				let square = BitboardUtils::pop_lsb(&mut black_pieces);
 
 				self.hash ^= self.hash_table.piece(piece, Color::BLACK, square);
 			}
@@ -82,10 +82,7 @@ impl Board {
 
 		self.hash ^= self.hash_table.color(self.color);
 		self.hash ^= self.hash_table.castle(self.castle_rights);
-
-		if let Some(en_passant) = self.en_passant {
-			self.hash ^= self.hash_table.en_passant(en_passant);
-		}
+		self.hash ^= self.hash_table.en_passant(self.en_passant);
 	}
 }
 

--- a/chess/src/board/mod.rs
+++ b/chess/src/board/mod.rs
@@ -10,7 +10,7 @@ pub mod pieces;
 pub mod square;
 pub mod zobrist;
 
-use bitboard::BitboardSquares;
+use bitboard::BitboardUtils;
 use color::ColorConsts;
 use piece::Pieces;
 use std::sync::Arc;
@@ -48,10 +48,10 @@ impl Board {
 	#[inline(always)]
 	pub fn add_piece(&mut self, piece: Piece, color: Color, square: Square) {
 		self.piece_list[square] = piece;
-		self.pieces[color][piece] |= Bitboard::SQUARES[square];
+		self.pieces[color][piece] |= BitboardUtils::SQUARES[square];
 
-		self.occupancy |= Bitboard::SQUARES[square];
-		self.occupancy_color[color] |= Bitboard::SQUARES[square];
+		self.occupancy |= BitboardUtils::SQUARES[square];
+		self.occupancy_color[color] |= BitboardUtils::SQUARES[square];
 
 		self.hash ^= self.hash_table.piece(piece, color, square);
 	}
@@ -59,10 +59,10 @@ impl Board {
 	#[inline(always)]
 	pub fn remove_piece(&mut self, piece: Piece, color: Color, square: Square) {
 		self.piece_list[square] = Piece::NONE;
-		self.pieces[color][piece] &= !(Bitboard::SQUARES[square]);
+		self.pieces[color][piece] &= !(BitboardUtils::SQUARES[square]);
 
-		self.occupancy &= !(Bitboard::SQUARES[square]);
-		self.occupancy_color[color] &= !(Bitboard::SQUARES[square]);
+		self.occupancy &= !(BitboardUtils::SQUARES[square]);
+		self.occupancy_color[color] &= !(BitboardUtils::SQUARES[square]);
 
 		self.hash ^= self.hash_table.piece(piece, color, square);
 	}
@@ -83,16 +83,16 @@ impl Board {
 
 	#[inline(always)]
 	pub fn set_en_passant(&mut self, square: Square) {
+		self.hash ^= self.hash_table.en_passant(self.en_passant);
 		self.en_passant = Some(square);
-		self.hash ^= self.hash_table.en_passant(square);
+		self.hash ^= self.hash_table.en_passant(self.en_passant);
 	}
 
 	#[inline(always)]
 	pub fn clear_en_passant(&mut self) {
-		if let Some(en_passant) = self.en_passant {
-			self.hash ^= self.hash_table.en_passant(en_passant);
-			self.en_passant = None;
-		}
+		self.hash ^= self.hash_table.en_passant(self.en_passant);
+		self.en_passant = None;
+		self.hash ^= self.hash_table.en_passant(self.en_passant);
 	}
 }
 

--- a/chess/src/board/pieces.rs
+++ b/chess/src/board/pieces.rs
@@ -1,9 +1,6 @@
-use crate::board::file_rank::RankUtils;
+use crate::board::{bitboard::BitboardUtils, file_rank::RankUtils};
 
-use super::{
-	bitboard::BitboardString, color::ColorConsts, piece::PieceConsts, square::SquareUtils,
-	Bitboard, Color, Piece,
-};
+use super::{color::ColorConsts, piece::PieceConsts, square::SquareUtils, Bitboard, Color, Piece};
 
 pub type PieceList = [Piece; SquareUtils::SIZE];
 pub type BitboardPieces = [[Bitboard; usize::PIECE_SIZE]; usize::COLOR_SIZE];
@@ -15,7 +12,9 @@ pub trait PrintBitboards {
 impl PrintBitboards for BitboardPieces {
 	fn print_bitboards(&self, color: Color) {
 		if let Some(bitboards) = self.get(color) {
-			let bitboards = bitboards.iter().map(|bitboard| bitboard.bitboard_string());
+			let bitboards = bitboards
+				.iter()
+				.map(|bitboard| BitboardUtils::to_string(*bitboard));
 
 			let lines = bitboards
 				.map(|s| s.lines().map(|s| s.to_string()).collect::<Vec<String>>())

--- a/chess/src/board/zobrist.rs
+++ b/chess/src/board/zobrist.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 type PieceTable = [[[ZobristHash; SquareUtils::SIZE]; Piece::PIECE_SIZE]; Color::COLOR_SIZE];
 type ColorTable = [ZobristHash; Color::COLOR_SIZE];
 type CastleTable = [ZobristHash; CastleRight::CASTLE_RIGHT_SIZE];
-type EnPassantTable = [ZobristHash; SquareUtils::SIZE];
+type EnPassantTable = [ZobristHash; SquareUtils::SIZE + 1];
 
 pub(crate) type ZobristHash = u64;
 
@@ -28,7 +28,7 @@ impl Default for HashTable {
 			pieces: [[[0; SquareUtils::SIZE]; Piece::PIECE_SIZE]; Color::COLOR_SIZE],
 			colors: [0; Color::COLOR_SIZE],
 			castles: [0; CastleRight::CASTLE_RIGHT_SIZE],
-			en_passant: [0; SquareUtils::SIZE],
+			en_passant: [0; SquareUtils::SIZE + 1],
 		};
 
 		hash_table.pieces.iter_mut().for_each(|color| {
@@ -73,7 +73,10 @@ impl HashTable {
 	}
 
 	#[inline(always)]
-	pub(super) fn en_passant(&self, square: Square) -> ZobristHash {
-		self.en_passant[square]
+	pub(super) fn en_passant(&self, en_passant: Option<Square>) -> ZobristHash {
+		match en_passant {
+			Some(en_passant) => self.en_passant[en_passant],
+			None => self.en_passant[SquareUtils::SIZE],
+		}
 	}
 }

--- a/chess/src/move_gen/impls/init.rs
+++ b/chess/src/move_gen/impls/init.rs
@@ -1,23 +1,23 @@
 use super::{Magic, MoveGen, BISHOP_TABLE_SIZE, ROOK_TABLE_SIZE};
 use crate::board::{
-	bitboard::{BitboardFiles, BitboardRanks, BitboardSquares},
+	bitboard::BitboardUtils,
 	color::{ColorConsts, Colors},
 	file_rank::{FileUtils, RankUtils},
 	piece::{PieceString, Pieces},
 	square::SquareUtils,
-	Bitboard, Color, Piece,
+	Color, Piece,
 };
 
 impl Default for MoveGen {
 	fn default() -> Self {
 		let mut move_gen = Self {
-			king: [Bitboard::default(); SquareUtils::SIZE],
-			rooks: vec![Bitboard::default(); ROOK_TABLE_SIZE],
-			bishops: vec![Bitboard::default(); BISHOP_TABLE_SIZE],
+			king: [BitboardUtils::EMPTY; SquareUtils::SIZE],
+			rooks: vec![BitboardUtils::EMPTY; ROOK_TABLE_SIZE],
+			bishops: vec![BitboardUtils::EMPTY; BISHOP_TABLE_SIZE],
 			rook_magics: [Magic::default(); SquareUtils::SIZE],
 			bishop_magics: [Magic::default(); SquareUtils::SIZE],
-			knight: [Bitboard::default(); SquareUtils::SIZE],
-			pawns: [[Bitboard::default(); SquareUtils::SIZE]; usize::COLOR_SIZE],
+			knight: [BitboardUtils::EMPTY; SquareUtils::SIZE],
+			pawns: [[BitboardUtils::EMPTY; SquareUtils::SIZE]; usize::COLOR_SIZE],
 		};
 
 		move_gen.init_king();
@@ -33,68 +33,75 @@ impl Default for MoveGen {
 impl MoveGen {
 	fn init_king(&mut self) {
 		for square in SquareUtils::RANGE {
-			let bitboard = Bitboard::SQUARES[square];
+			let bitboard = BitboardUtils::SQUARES[square];
 
-			self.king[square] |=
-				(bitboard & !Bitboard::FILES[FileUtils::A] & !Bitboard::RANKS[RankUtils::R8]) << 7
-					| (bitboard & !Bitboard::RANKS[RankUtils::R8]) << 8
-					| (bitboard & !Bitboard::RANKS[RankUtils::R8] & !Bitboard::FILES[FileUtils::H])
-						<< 9 | (bitboard & !Bitboard::FILES[FileUtils::H]) << 1
-					| (bitboard & !Bitboard::RANKS[RankUtils::R1] & !Bitboard::FILES[FileUtils::H])
-						>> 7 | (bitboard & !Bitboard::RANKS[RankUtils::R1]) >> 8
-					| (bitboard & !Bitboard::RANKS[RankUtils::R1] & !Bitboard::FILES[FileUtils::A])
-						>> 9 | (bitboard & !Bitboard::FILES[FileUtils::A]) >> 1;
+			self.king[square] |= (bitboard
+				& !BitboardUtils::FILES[FileUtils::A]
+				& !BitboardUtils::RANKS[RankUtils::R8])
+				<< 7 | (bitboard & !BitboardUtils::RANKS[RankUtils::R8]) << 8
+				| (bitboard
+					& !BitboardUtils::RANKS[RankUtils::R8]
+					& !BitboardUtils::FILES[FileUtils::H])
+					<< 9 | (bitboard & !BitboardUtils::FILES[FileUtils::H]) << 1
+				| (bitboard
+					& !BitboardUtils::RANKS[RankUtils::R1]
+					& !BitboardUtils::FILES[FileUtils::H])
+					>> 7 | (bitboard & !BitboardUtils::RANKS[RankUtils::R1]) >> 8
+				| (bitboard
+					& !BitboardUtils::RANKS[RankUtils::R1]
+					& !BitboardUtils::FILES[FileUtils::A])
+					>> 9 | (bitboard & !BitboardUtils::FILES[FileUtils::A]) >> 1;
 		}
 	}
 
 	fn init_knight(&mut self) {
 		for square in SquareUtils::RANGE {
-			let bitboard = Bitboard::SQUARES[square];
+			let bitboard = BitboardUtils::SQUARES[square];
 
 			self.knight[square] |= (bitboard
-				& !Bitboard::RANKS[RankUtils::R8]
-				& !Bitboard::RANKS[RankUtils::R7]
-				& !Bitboard::FILES[FileUtils::A])
+				& !BitboardUtils::RANKS[RankUtils::R8]
+				& !BitboardUtils::RANKS[RankUtils::R7]
+				& !BitboardUtils::FILES[FileUtils::A])
 				<< 15 | (bitboard
-				& !Bitboard::RANKS[RankUtils::R8]
-				& !Bitboard::RANKS[RankUtils::R7]
-				& !Bitboard::FILES[FileUtils::H])
+				& !BitboardUtils::RANKS[RankUtils::R8]
+				& !BitboardUtils::RANKS[RankUtils::R7]
+				& !BitboardUtils::FILES[FileUtils::H])
 				<< 17 | (bitboard
-				& !Bitboard::RANKS[RankUtils::R8]
-				& !Bitboard::FILES[FileUtils::A]
-				& !Bitboard::FILES[FileUtils::B])
+				& !BitboardUtils::RANKS[RankUtils::R8]
+				& !BitboardUtils::FILES[FileUtils::A]
+				& !BitboardUtils::FILES[FileUtils::B])
 				<< 6 | (bitboard
-				& !Bitboard::RANKS[RankUtils::R8]
-				& !Bitboard::FILES[FileUtils::G]
-				& !Bitboard::FILES[FileUtils::H])
+				& !BitboardUtils::RANKS[RankUtils::R8]
+				& !BitboardUtils::FILES[FileUtils::G]
+				& !BitboardUtils::FILES[FileUtils::H])
 				<< 10 | (bitboard
-				& !Bitboard::RANKS[RankUtils::R1]
-				& !Bitboard::RANKS[RankUtils::R2]
-				& !Bitboard::FILES[FileUtils::A])
+				& !BitboardUtils::RANKS[RankUtils::R1]
+				& !BitboardUtils::RANKS[RankUtils::R2]
+				& !BitboardUtils::FILES[FileUtils::A])
 				>> 17 | (bitboard
-				& !Bitboard::RANKS[RankUtils::R1]
-				& !Bitboard::RANKS[RankUtils::R2]
-				& !Bitboard::FILES[FileUtils::H])
+				& !BitboardUtils::RANKS[RankUtils::R1]
+				& !BitboardUtils::RANKS[RankUtils::R2]
+				& !BitboardUtils::FILES[FileUtils::H])
 				>> 15 | (bitboard
-				& !Bitboard::RANKS[RankUtils::R1]
-				& !Bitboard::FILES[FileUtils::A]
-				& !Bitboard::FILES[FileUtils::B])
+				& !BitboardUtils::RANKS[RankUtils::R1]
+				& !BitboardUtils::FILES[FileUtils::A]
+				& !BitboardUtils::FILES[FileUtils::B])
 				>> 10 | (bitboard
-				& !Bitboard::RANKS[RankUtils::R1]
-				& !Bitboard::FILES[FileUtils::G]
-				& !Bitboard::FILES[FileUtils::H])
+				& !BitboardUtils::RANKS[RankUtils::R1]
+				& !BitboardUtils::FILES[FileUtils::G]
+				& !BitboardUtils::FILES[FileUtils::H])
 				>> 6;
 		}
 	}
 
 	fn init_pawn(&mut self) {
 		for square in SquareUtils::RANGE {
-			let bitboard = Bitboard::SQUARES[square];
+			let bitboard = BitboardUtils::SQUARES[square];
 
-			let white = (bitboard & !Bitboard::FILES[FileUtils::A]) << 7
-				| (bitboard & !Bitboard::FILES[FileUtils::H]) << 9;
-			let black = (bitboard & !Bitboard::FILES[FileUtils::H]) >> 7
-				| (bitboard & !Bitboard::FILES[FileUtils::A]) >> 9;
+			let white = (bitboard & !BitboardUtils::FILES[FileUtils::A]) << 7
+				| (bitboard & !BitboardUtils::FILES[FileUtils::H]) << 9;
+			let black = (bitboard & !BitboardUtils::FILES[FileUtils::H]) >> 7
+				| (bitboard & !BitboardUtils::FILES[FileUtils::A]) >> 9;
 
 			self.pawns[Color::WHITE][square] = white;
 			self.pawns[Color::BLACK][square] = black;

--- a/chess/src/move_gen/impls/mask.rs
+++ b/chess/src/move_gen/impls/mask.rs
@@ -1,6 +1,6 @@
 use super::{AttackTable, BlockerTable, Direction, MoveGen};
 use crate::board::{
-	bitboard::{BitboardFiles, BitboardOccupied, BitboardRanks, BitboardSquares},
+	bitboard::BitboardUtils,
 	file_rank::{FileUtils, RankUtils},
 	square::SquareUtils,
 	Bitboard, Square,
@@ -11,19 +11,19 @@ impl MoveGen {
 		let edges = Self::edges(square);
 		let (file, rank) = SquareUtils::location(square);
 
-		let mask = Bitboard::RANKS[rank] | Bitboard::FILES[file];
+		let mask = BitboardUtils::RANKS[rank] | BitboardUtils::FILES[file];
 
-		mask & !edges & !Bitboard::SQUARES[square]
+		mask & !edges & !BitboardUtils::SQUARES[square]
 	}
 
 	pub fn bishop_mask(square: Square) -> Bitboard {
 		let edges = Self::edges(square);
-		let mask = Self::ray(Bitboard::default(), square, Direction::NorthEast)
-			| Self::ray(Bitboard::default(), square, Direction::NorthWest)
-			| Self::ray(Bitboard::default(), square, Direction::SouthEast)
-			| Self::ray(Bitboard::default(), square, Direction::SouthWest);
+		let mask = Self::ray(BitboardUtils::EMPTY, square, Direction::NorthEast)
+			| Self::ray(BitboardUtils::EMPTY, square, Direction::NorthWest)
+			| Self::ray(BitboardUtils::EMPTY, square, Direction::SouthEast)
+			| Self::ray(BitboardUtils::EMPTY, square, Direction::SouthWest);
 
-		mask & !edges & !Bitboard::SQUARES[square]
+		mask & !edges & !BitboardUtils::SQUARES[square]
 	}
 
 	pub fn rook_attacks(square: Square, blockers: &BlockerTable) -> AttackTable {
@@ -58,7 +58,7 @@ impl MoveGen {
 
 	pub fn blockers(mask: Bitboard) -> BlockerTable {
 		let mut blockers = BlockerTable::default();
-		let mut bitboard = Bitboard::default();
+		let mut bitboard = BitboardUtils::EMPTY;
 
 		// Carry-Rippler
 		// https://www.chessprogramming.org/Traversing_Subsets_of_a_Set
@@ -77,23 +77,23 @@ impl MoveGen {
 	fn edges(square: Square) -> Bitboard {
 		let (file, rank) = SquareUtils::location(square);
 
-		let bitboard_file = Bitboard::FILES[file];
-		let bitboard_rank = Bitboard::RANKS[rank];
+		let bitboard_file = BitboardUtils::FILES[file];
+		let bitboard_rank = BitboardUtils::RANKS[rank];
 
-		(!bitboard_file & Bitboard::FILES[FileUtils::A])
-			| (!bitboard_file & Bitboard::FILES[FileUtils::H])
-			| (!bitboard_rank & Bitboard::RANKS[RankUtils::R1])
-			| (!bitboard_rank & Bitboard::RANKS[RankUtils::R8])
+		(!bitboard_file & BitboardUtils::FILES[FileUtils::A])
+			| (!bitboard_file & BitboardUtils::FILES[FileUtils::H])
+			| (!bitboard_rank & BitboardUtils::RANKS[RankUtils::R1])
+			| (!bitboard_rank & BitboardUtils::RANKS[RankUtils::R8])
 	}
 
 	fn ray(bitboard: Bitboard, mut square: Square, direction: Direction) -> Bitboard {
-		let mut ray = Bitboard::default();
+		let mut ray = BitboardUtils::EMPTY;
 
 		while !(direction == square) {
 			square += direction;
-			ray |= Bitboard::SQUARES[square];
+			ray |= BitboardUtils::SQUARES[square];
 
-			if bitboard.occupied(square) {
+			if BitboardUtils::occupied(bitboard, square) {
 				break;
 			}
 		}

--- a/chess/src/move_gen/magic.rs
+++ b/chess/src/move_gen/magic.rs
@@ -47,7 +47,7 @@ pub mod gen {
 	use std::time::Instant;
 
 	use super::super::{Magic, MoveGen, BISHOP_TABLE_SIZE, ROOK_TABLE_SIZE};
-	use crate::board::{piece::Pieces, square::SquareUtils, Bitboard, Piece};
+	use crate::board::{bitboard::BitboardUtils, piece::Pieces, square::SquareUtils, Piece};
 	use rand::Rng;
 
 	impl Magic {
@@ -61,8 +61,8 @@ pub mod gen {
 			};
 
 			let mut table = match is_rook {
-				true => vec![Bitboard::default(); ROOK_TABLE_SIZE],
-				false => vec![Bitboard::default(); BISHOP_TABLE_SIZE],
+				true => vec![BitboardUtils::EMPTY; ROOK_TABLE_SIZE],
+				false => vec![BitboardUtils::EMPTY; BISHOP_TABLE_SIZE],
 			};
 
 			let mut random = rand::thread_rng();
@@ -113,7 +113,7 @@ pub mod gen {
 							table[index] = attacks[next];
 						} else {
 							for wipe_index in offset..=end {
-								table[wipe_index as usize] = Bitboard::default();
+								table[wipe_index as usize] = BitboardUtils::EMPTY;
 							}
 
 							found = false;

--- a/chess/src/playmove.rs
+++ b/chess/src/playmove.rs
@@ -1,6 +1,6 @@
 use crate::{
 	board::{
-		bitboard::BitboardLSB,
+		bitboard::BitboardUtils,
 		castle_right::{CastleRightSquares, CastleRights},
 		color::Colors,
 		piece::Pieces,
@@ -101,10 +101,11 @@ impl Chess {
 			board.fullmove_number += 1;
 		}
 
-		let legal =
-			!self
-				.move_gen
-				.square_attacked(board, opponent, board.pieces[color][Piece::KING].lsb());
+		let legal = !self.move_gen.square_attacked(
+			board,
+			opponent,
+			BitboardUtils::lsb(board.pieces[color][Piece::KING]),
+		);
 
 		if !legal {
 			self.undo_move();


### PR DESCRIPTION
This is to prevent form importing multiple **traits** related to `bitboard`.