### PR TITLE
refactor: color to use `ColorUtils` struct instead of traits

### DIFF
--- a/chess/src/board/color.rs
+++ b/chess/src/board/color.rs
@@ -1,53 +1,39 @@
 pub type Color = usize;
 
-pub trait Colors {
-	const WHITE: Color = 0;
-	const BLACK: Color = 1;
-	const BOTH: Color = 2;
+pub struct ColorUtils;
+
+impl ColorUtils {
+	pub const SIZE: usize = 2;
+	pub const RANGE: std::ops::Range<Color> = 0..Self::SIZE;
 }
 
-pub trait ColorConsts {
-	const COLOR_SIZE: usize = 2;
-	const COLOR_RANGE: std::ops::Range<Color> = 0..Self::COLOR_SIZE;
+impl ColorUtils {
+	pub const WHITE: Color = 0;
+	pub const BLACK: Color = 1;
+	pub const BOTH: Color = 2;
 }
 
-impl Colors for Color {}
-impl ColorConsts for usize {}
-
-pub trait GetColor<T> {
-	fn get_color(value: T) -> Self;
-}
-
-impl GetColor<char> for Color {
-	fn get_color(value: char) -> Self {
+impl ColorUtils {
+	pub fn parse(value: char) -> Color {
 		match value {
 			'w' | 'W' => Self::WHITE,
 			'b' | 'B' => Self::BLACK,
 			_ => panic!("Invalid color: {}", value),
 		}
 	}
-}
 
-impl GetColor<bool> for Color {
-	fn get_color(value: bool) -> Self {
+	pub fn from_bool(value: bool) -> Color {
 		match value {
 			true => Self::WHITE,
 			false => Self::BLACK,
 		}
 	}
-}
 
-pub trait ColorString {
-	fn color_string(&self) -> String;
-}
-
-impl ColorString for Color {
-	fn color_string(&self) -> String {
-		String::from(match *self {
+	pub fn to_string(value: Color) -> String {
+		String::from(match value {
 			Self::WHITE => "w",
 			Self::BLACK => "b",
-			Self::BOTH => "Both",
-			_ => panic!("Invalid color: {}", self),
+			_ => panic!("Invalid color: {}", value),
 		})
 	}
 }

--- a/chess/src/board/impls/display.rs
+++ b/chess/src/board/impls/display.rs
@@ -2,11 +2,8 @@ use castle_right::CastleRightString;
 use file_rank::{FileUtils, RankUtils};
 use square::SquareUtils;
 
+use super::piece::PieceString;
 use super::*;
-use super::{
-	color::{ColorConsts, ColorString},
-	piece::PieceString,
-};
 use std::fmt;
 
 impl fmt::Display for Board {
@@ -22,7 +19,7 @@ impl Board {
 		if piece == Piece::NONE {
 			None
 		} else {
-			for color in Color::COLOR_RANGE {
+			for color in ColorUtils::RANGE {
 				if BitboardUtils::occupied(self.pieces[color][piece], square) {
 					return Some((piece, color));
 				}
@@ -84,7 +81,7 @@ impl Board {
 			}
 		}
 
-		let color = self.color.color_string();
+		let color = ColorUtils::to_string(self.color);
 		let castle_rights = &self.castle_rights.castle_right_string();
 
 		let en_passant = match self.en_passant {

--- a/chess/src/board/impls/from.rs
+++ b/chess/src/board/impls/from.rs
@@ -3,11 +3,8 @@ use castle_right::GetCastleRight;
 use file_rank::{FileUtils, RankUtils};
 use square::SquareUtils;
 
+use super::piece::{GetPiece, PieceConsts};
 use super::*;
-use super::{
-	color::{ColorConsts, Colors, GetColor},
-	piece::{GetPiece, PieceConsts},
-};
 
 impl From<&str> for Board {
 	fn from(value: &str) -> Self {
@@ -18,14 +15,14 @@ impl From<&str> for Board {
 impl From<(&str, Arc<HashTable>)> for Board {
 	fn from(value: (&str, Arc<HashTable>)) -> Self {
 		let mut board = Self {
-			pieces: [[BitboardUtils::EMPTY; usize::PIECE_SIZE]; usize::COLOR_SIZE],
-			color: Color::WHITE,
+			pieces: [[BitboardUtils::EMPTY; usize::PIECE_SIZE]; ColorUtils::SIZE],
+			color: ColorUtils::WHITE,
 			en_passant: None,
 			castle_rights: CastleRight::default(),
 
 			piece_list: [Piece::NONE; SquareUtils::SIZE],
 			occupancy: BitboardUtils::EMPTY,
-			occupancy_color: [BitboardUtils::EMPTY; usize::COLOR_SIZE],
+			occupancy_color: [BitboardUtils::EMPTY; ColorUtils::SIZE],
 
 			halfmove_clock: 0,
 			fullmove_number: 1,
@@ -60,8 +57,8 @@ impl Board {
 	fn init_hash(&mut self) {
 		self.hash = 0;
 
-		let bb_white = self.pieces[usize::WHITE];
-		let bb_black = self.pieces[usize::BLACK];
+		let bb_white = self.pieces[ColorUtils::WHITE];
+		let bb_black = self.pieces[ColorUtils::BLACK];
 
 		for (piece, (white, black)) in bb_white.iter().zip(bb_black.iter()).enumerate() {
 			let mut white_pieces = *white;
@@ -70,13 +67,13 @@ impl Board {
 			while white_pieces > 0 {
 				let square = BitboardUtils::pop_lsb(&mut white_pieces);
 
-				self.hash ^= self.hash_table.piece(piece, Color::WHITE, square);
+				self.hash ^= self.hash_table.piece(piece, ColorUtils::WHITE, square);
 			}
 
 			while black_pieces > 0 {
 				let square = BitboardUtils::pop_lsb(&mut black_pieces);
 
-				self.hash ^= self.hash_table.piece(piece, Color::BLACK, square);
+				self.hash ^= self.hash_table.piece(piece, ColorUtils::BLACK, square);
 			}
 		}
 
@@ -107,7 +104,7 @@ impl BoardBuilder {
 				_ => {
 					board.add_piece(
 						Piece::get_piece(ch),
-						Color::get_color(ch.is_uppercase()),
+						ColorUtils::from_bool(ch.is_uppercase()),
 						SquareUtils::from_location(file, rank),
 					);
 					file += 1;
@@ -118,7 +115,7 @@ impl BoardBuilder {
 
 	fn set_color(board: &mut Board, color: &str) {
 		if let Some(ch) = color.chars().next() {
-			board.color = Color::get_color(ch);
+			board.color = ColorUtils::parse(ch);
 		}
 	}
 

--- a/chess/src/board/mod.rs
+++ b/chess/src/board/mod.rs
@@ -11,7 +11,7 @@ pub mod square;
 pub mod zobrist;
 
 use bitboard::BitboardUtils;
-use color::ColorConsts;
+use color::ColorUtils;
 use piece::Pieces;
 use std::sync::Arc;
 use zobrist::{HashTable, ZobristHash};
@@ -28,7 +28,7 @@ pub struct Board {
 	pub piece_list: PieceList,
 
 	pub occupancy: Bitboard,
-	pub occupancy_color: [Bitboard; usize::COLOR_SIZE],
+	pub occupancy_color: [Bitboard; ColorUtils::SIZE],
 
 	pub halfmove_clock: u8,
 	pub fullmove_number: u16,

--- a/chess/src/board/piece.rs
+++ b/chess/src/board/piece.rs
@@ -1,4 +1,4 @@
-use super::{color::Colors, Color};
+use super::{color::ColorUtils, Color};
 
 pub type Piece = usize;
 
@@ -61,9 +61,9 @@ impl PieceString for Piece {
 		};
 
 		String::from(match color {
-			Color::WHITE => ch,
-			Color::BLACK => ch.to_ascii_lowercase(),
-			Color::BOTH => {
+			ColorUtils::WHITE => ch,
+			ColorUtils::BLACK => ch.to_ascii_lowercase(),
+			ColorUtils::BOTH => {
 				let piece = match *self {
 					Piece::PAWN => "Pawn",
 					Piece::KNIGHT => "Knight",

--- a/chess/src/board/pieces.rs
+++ b/chess/src/board/pieces.rs
@@ -1,9 +1,9 @@
 use crate::board::{bitboard::BitboardUtils, file_rank::RankUtils};
 
-use super::{color::ColorConsts, piece::PieceConsts, square::SquareUtils, Bitboard, Color, Piece};
+use super::{color::ColorUtils, piece::PieceConsts, square::SquareUtils, Bitboard, Color, Piece};
 
 pub type PieceList = [Piece; SquareUtils::SIZE];
-pub type BitboardPieces = [[Bitboard; usize::PIECE_SIZE]; usize::COLOR_SIZE];
+pub type BitboardPieces = [[Bitboard; usize::PIECE_SIZE]; ColorUtils::SIZE];
 
 pub trait PrintBitboards {
 	fn print_bitboards(&self, color: Color);

--- a/chess/src/board/zobrist.rs
+++ b/chess/src/board/zobrist.rs
@@ -1,12 +1,12 @@
 use super::{
-	castle_right::CastleRightConsts, color::ColorConsts, piece::PieceConsts, square::SquareUtils,
+	castle_right::CastleRightConsts, color::ColorUtils, piece::PieceConsts, square::SquareUtils,
 	CastleRight, Color, Piece, Square,
 };
 
 use rand::Rng;
 
-type PieceTable = [[[ZobristHash; SquareUtils::SIZE]; Piece::PIECE_SIZE]; Color::COLOR_SIZE];
-type ColorTable = [ZobristHash; Color::COLOR_SIZE];
+type PieceTable = [[[ZobristHash; SquareUtils::SIZE]; Piece::PIECE_SIZE]; ColorUtils::SIZE];
+type ColorTable = [ZobristHash; ColorUtils::SIZE];
 type CastleTable = [ZobristHash; CastleRight::CASTLE_RIGHT_SIZE];
 type EnPassantTable = [ZobristHash; SquareUtils::SIZE + 1];
 
@@ -25,8 +25,8 @@ impl Default for HashTable {
 		let mut random = rand::thread_rng();
 
 		let mut hash_table = Self {
-			pieces: [[[0; SquareUtils::SIZE]; Piece::PIECE_SIZE]; Color::COLOR_SIZE],
-			colors: [0; Color::COLOR_SIZE],
+			pieces: [[[0; SquareUtils::SIZE]; Piece::PIECE_SIZE]; ColorUtils::SIZE],
+			colors: [0; ColorUtils::SIZE],
 			castles: [0; CastleRight::CASTLE_RIGHT_SIZE],
 			en_passant: [0; SquareUtils::SIZE + 1],
 		};

--- a/chess/src/move_gen/impls/init.rs
+++ b/chess/src/move_gen/impls/init.rs
@@ -1,11 +1,11 @@
 use super::{Magic, MoveGen, BISHOP_TABLE_SIZE, ROOK_TABLE_SIZE};
 use crate::board::{
 	bitboard::BitboardUtils,
-	color::{ColorConsts, Colors},
+	color::ColorUtils,
 	file_rank::{FileUtils, RankUtils},
 	piece::{PieceString, Pieces},
 	square::SquareUtils,
-	Color, Piece,
+	Piece,
 };
 
 impl Default for MoveGen {
@@ -17,7 +17,7 @@ impl Default for MoveGen {
 			rook_magics: [Magic::default(); SquareUtils::SIZE],
 			bishop_magics: [Magic::default(); SquareUtils::SIZE],
 			knight: [BitboardUtils::EMPTY; SquareUtils::SIZE],
-			pawns: [[BitboardUtils::EMPTY; SquareUtils::SIZE]; usize::COLOR_SIZE],
+			pawns: [[BitboardUtils::EMPTY; SquareUtils::SIZE]; ColorUtils::SIZE],
 		};
 
 		move_gen.init_king();
@@ -103,8 +103,8 @@ impl MoveGen {
 			let black = (bitboard & !BitboardUtils::FILES[FileUtils::H]) >> 7
 				| (bitboard & !BitboardUtils::FILES[FileUtils::A]) >> 9;
 
-			self.pawns[Color::WHITE][square] = white;
-			self.pawns[Color::BLACK][square] = black;
+			self.pawns[ColorUtils::WHITE][square] = white;
+			self.pawns[ColorUtils::BLACK][square] = black;
 		}
 	}
 
@@ -114,7 +114,10 @@ impl MoveGen {
 		let is_rook = match piece {
 			Piece::ROOK => true,
 			Piece::BISHOP => false,
-			_ => panic!("Invalid magic piece: {}", piece.piece_string(Color::BOTH)),
+			_ => panic!(
+				"Invalid magic piece: {}",
+				piece.piece_string(ColorUtils::BOTH)
+			),
 		};
 
 		let mut offset = 0;

--- a/chess/src/move_gen/mod.rs
+++ b/chess/src/move_gen/mod.rs
@@ -9,11 +9,11 @@ use crate::{
 	board::{
 		bitboard::BitboardUtils,
 		castle_right::CastleRights,
-		color::{ColorConsts, ColorString, Colors},
+		color::ColorUtils,
 		file_rank::RankUtils,
 		piece::{PiecePromotions, Pieces},
 		square::SquareUtils,
-		Bitboard, Board, CastleRight, Color, Piece, Square,
+		Bitboard, Board, CastleRight, Piece, Square,
 	},
 	move_list::MoveList,
 };
@@ -27,7 +27,7 @@ pub struct MoveGen {
 	rook_magics: PieceMagics,
 	bishop_magics: PieceMagics,
 	knight: PieceMoves,
-	pawns: [PieceMoves; usize::COLOR_SIZE],
+	pawns: [PieceMoves; ColorUtils::SIZE],
 }
 
 impl MoveGen {
@@ -119,15 +119,15 @@ impl MoveGen {
 		let empty = !board.occupancy;
 
 		let fourth = match color {
-			Color::WHITE => RankUtils::R4,
-			Color::BLACK => RankUtils::R5,
-			_ => panic!("Invalid color: {}", color.color_string()),
+			ColorUtils::WHITE => RankUtils::R4,
+			ColorUtils::BLACK => RankUtils::R5,
+			_ => panic!("Invalid color: {color}"),
 		};
 
 		let direction = match color {
-			Color::WHITE => Direction::North,
-			Color::BLACK => Direction::South,
-			_ => panic!("Invalid color: {}", color.color_string()),
+			ColorUtils::WHITE => Direction::North,
+			ColorUtils::BLACK => Direction::South,
+			_ => panic!("Invalid color: {color}"),
 		};
 
 		let rotation_count = (SquareUtils::SIZE + direction) as u32;
@@ -163,7 +163,7 @@ impl MoveGen {
 
 		let rights = board.castle_rights;
 
-		if color == Color::WHITE && rights & CastleRight::WHITE > 0 {
+		if color == ColorUtils::WHITE && rights & CastleRight::WHITE > 0 {
 			if rights & CastleRight::WHITE_KING > 0 {
 				let blockers = BitboardUtils::SQUARES[SquareUtils::F1]
 					| BitboardUtils::SQUARES[SquareUtils::G1];
@@ -200,7 +200,7 @@ impl MoveGen {
 					);
 				}
 			}
-		} else if color == Color::BLACK && rights & CastleRight::BLACK > 0 {
+		} else if color == ColorUtils::BLACK && rights & CastleRight::BLACK > 0 {
 			if rights & CastleRight::BLACK_KING > 0 {
 				let blockers = BitboardUtils::SQUARES[SquareUtils::F8]
 					| BitboardUtils::SQUARES[SquareUtils::G8];
@@ -256,9 +256,9 @@ impl MoveGen {
 		let is_pawn = Piece::PAWN == piece;
 
 		let promotion_rank = match color {
-			Color::WHITE => RankUtils::R8,
-			Color::BLACK => RankUtils::R1,
-			_ => panic!("Invalid color: {}", color.color_string()),
+			ColorUtils::WHITE => RankUtils::R8,
+			ColorUtils::BLACK => RankUtils::R1,
+			_ => panic!("Invalid color: {color}"),
 		};
 
 		while moves > 0 {

--- a/chess/src/move_gen/piece_move.rs
+++ b/chess/src/move_gen/piece_move.rs
@@ -1,7 +1,7 @@
 // Marcel Vanthoor
 // https://github.com/mvanthoor/rustic
 
-use crate::board::{color::Colors, piece::PieceString, square::SquareUtils, Color, Piece, Square};
+use crate::board::{color::ColorUtils, piece::PieceString, square::SquareUtils, Piece, Square};
 use std::fmt::{self, Debug};
 
 #[derive(Copy, Clone, PartialEq)]
@@ -32,9 +32,9 @@ impl Debug for Move {
 			"{}{} {} {} {} {en_passant} {two_step} {castling}",
 			SquareUtils::to_string(from),
 			SquareUtils::to_string(to),
-			piece.piece_string(Color::BOTH),
-			captured.piece_string(Color::BOTH),
-			promoted.piece_string(Color::BOTH),
+			piece.piece_string(ColorUtils::BOTH),
+			captured.piece_string(ColorUtils::BOTH),
+			promoted.piece_string(ColorUtils::BOTH),
 		)
 	}
 }

--- a/chess/src/playmove.rs
+++ b/chess/src/playmove.rs
@@ -2,10 +2,10 @@ use crate::{
 	board::{
 		bitboard::BitboardUtils,
 		castle_right::{CastleRightSquares, CastleRights},
-		color::Colors,
+		color::ColorUtils,
 		piece::Pieces,
 		square::SquareUtils,
-		CastleRight, Color, Piece,
+		CastleRight, Piece,
 	},
 	history::OldState,
 	move_gen::Move,
@@ -97,7 +97,7 @@ impl Chess {
 
 		board.switch_color();
 
-		if color == Color::BLACK {
+		if color == ColorUtils::BLACK {
 			board.fullmove_number += 1;
 		}
 

--- a/engine/src/args.rs
+++ b/engine/src/args.rs
@@ -1,5 +1,5 @@
 use chess::{
-	board::{color::Colors, piece::Pieces, pieces::PrintBitboards, Board, Color},
+	board::{color::ColorUtils, piece::Pieces, pieces::PrintBitboards, Board, Color},
 	move_gen::MoveGen,
 	Chess,
 };
@@ -64,9 +64,9 @@ pub fn display(fen: Option<String>, bitboards: bool) {
 		false => println!("{board}"),
 		true => {
 			println!("White Pieces:");
-			board.pieces.print_bitboards(Color::WHITE);
+			board.pieces.print_bitboards(ColorUtils::WHITE);
 			println!("Black Pieces:");
-			board.pieces.print_bitboards(Color::BLACK);
+			board.pieces.print_bitboards(ColorUtils::BLACK);
 		}
 	}
 }


### PR DESCRIPTION
This is to prevent form importing multiple **traits** related to `color`.