### PR TITLE
refactor: castle right to use `CastleRightUtils` instead of traits

### DIFF
--- a/chess/src/board/castle_right.rs
+++ b/chess/src/board/castle_right.rs
@@ -2,48 +2,42 @@ use super::square::SquareUtils;
 
 pub type CastleRight = u8;
 
-pub trait CastleRightConsts {
-	const CASTLE_RIGHT_SIZE: usize = 16;
+pub struct CastleRightUtils;
+
+impl CastleRightUtils {
+	pub const SIZE: usize = 16;
 }
 
-pub trait CastleRights {
-	const NONE: CastleRight = 0;
-	const WHITE_KING: CastleRight = 1;
-	const WHITE_QUEEN: CastleRight = 2;
-	const BLACK_KING: CastleRight = 4;
-	const BLACK_QUEEN: CastleRight = 8;
-	const ALL: CastleRight = 15;
+impl CastleRightUtils {
+	pub const NONE: CastleRight = 0;
+	pub const WHITE_KING: CastleRight = 1;
+	pub const WHITE_QUEEN: CastleRight = 2;
+	pub const BLACK_KING: CastleRight = 4;
+	pub const BLACK_QUEEN: CastleRight = 8;
+	pub const ALL: CastleRight = 15;
 
-	const WHITE: CastleRight = Self::WHITE_KING | Self::WHITE_QUEEN;
-	const BLACK: CastleRight = Self::BLACK_KING | Self::BLACK_QUEEN;
+	pub const WHITE: CastleRight = Self::WHITE_KING | Self::WHITE_QUEEN;
+	pub const BLACK: CastleRight = Self::BLACK_KING | Self::BLACK_QUEEN;
 }
 
-pub trait CastleRightSquares {
-	const SQUARES: [CastleRight; SquareUtils::SIZE] = {
-		let mut squares = [CastleRight::NONE; SquareUtils::SIZE];
+impl CastleRightUtils {
+	pub const SQUARES: [CastleRight; SquareUtils::SIZE] = {
+		let mut squares = [Self::NONE; SquareUtils::SIZE];
 
-		squares[SquareUtils::A1] = CastleRight::WHITE_QUEEN;
-		squares[SquareUtils::E1] = CastleRight::WHITE_KING | CastleRight::WHITE_QUEEN;
-		squares[SquareUtils::H1] = CastleRight::WHITE_KING;
+		squares[SquareUtils::A1] = Self::WHITE_QUEEN;
+		squares[SquareUtils::E1] = Self::WHITE_KING | Self::WHITE_QUEEN;
+		squares[SquareUtils::H1] = Self::WHITE_KING;
 
-		squares[SquareUtils::A8] = CastleRight::BLACK_QUEEN;
-		squares[SquareUtils::E8] = CastleRight::BLACK_KING | CastleRight::BLACK_QUEEN;
-		squares[SquareUtils::H8] = CastleRight::BLACK_KING;
+		squares[SquareUtils::A8] = Self::BLACK_QUEEN;
+		squares[SquareUtils::E8] = Self::BLACK_KING | Self::BLACK_QUEEN;
+		squares[SquareUtils::H8] = Self::BLACK_KING;
 
 		squares
 	};
 }
 
-impl CastleRightConsts for CastleRight {}
-impl CastleRights for CastleRight {}
-impl CastleRightSquares for CastleRight {}
-
-pub trait GetCastleRight<T> {
-	fn get_castle_right(value: T) -> Self;
-}
-
-impl GetCastleRight<char> for CastleRight {
-	fn get_castle_right(value: char) -> Self {
+impl CastleRightUtils {
+	pub fn parse(value: char) -> CastleRight {
 		match value {
 			'K' => Self::WHITE_KING,
 			'Q' => Self::WHITE_QUEEN,
@@ -52,26 +46,20 @@ impl GetCastleRight<char> for CastleRight {
 			_ => panic!("Invalid castle right: {}", value),
 		}
 	}
-}
 
-pub trait CastleRightString {
-	fn castle_right_string(&self) -> String;
-}
-
-impl CastleRightString for CastleRight {
-	fn castle_right_string(&self) -> String {
+	pub fn to_string(castle_right: CastleRight) -> String {
 		let mut result = String::new();
 
-		if self & CastleRight::WHITE_KING > 0 {
+		if castle_right & Self::WHITE_KING > 0 {
 			result.push('K');
 		}
-		if self & CastleRight::WHITE_QUEEN > 0 {
+		if castle_right & Self::WHITE_QUEEN > 0 {
 			result.push('Q');
 		}
-		if self & CastleRight::BLACK_KING > 0 {
+		if castle_right & Self::BLACK_KING > 0 {
 			result.push('k');
 		}
-		if self & CastleRight::BLACK_QUEEN > 0 {
+		if castle_right & Self::BLACK_QUEEN > 0 {
 			result.push('q');
 		}
 

--- a/chess/src/board/impls/display.rs
+++ b/chess/src/board/impls/display.rs
@@ -1,4 +1,4 @@
-use castle_right::CastleRightString;
+use castle_right::CastleRightUtils;
 use file_rank::{FileUtils, RankUtils};
 use square::SquareUtils;
 
@@ -82,7 +82,7 @@ impl Board {
 		}
 
 		let color = ColorUtils::to_string(self.color);
-		let castle_rights = &self.castle_rights.castle_right_string();
+		let castle_rights = CastleRightUtils::to_string(self.castle_rights);
 
 		let en_passant = match self.en_passant {
 			Some(square) => SquareUtils::to_string(square),

--- a/chess/src/board/impls/from.rs
+++ b/chess/src/board/impls/from.rs
@@ -1,5 +1,5 @@
 use bitboard::BitboardUtils;
-use castle_right::GetCastleRight;
+use castle_right::CastleRightUtils;
 use file_rank::{FileUtils, RankUtils};
 use square::SquareUtils;
 
@@ -125,7 +125,7 @@ impl BoardBuilder {
 		}
 
 		for ch in castling_rights.chars() {
-			board.castle_rights |= CastleRight::get_castle_right(ch);
+			board.castle_rights |= CastleRightUtils::parse(ch);
 		}
 	}
 

--- a/chess/src/board/pieces.rs
+++ b/chess/src/board/pieces.rs
@@ -22,10 +22,10 @@ impl PrintBitboards for BitboardPieces {
 
 			let mut output = format!(
 				"\n{:<17}{:<17}{:<17}{:<17}{:<17}{:<17}",
-				"King", "Queen", "Rook", "Bishop", "Knight", "Pawn"
+				"Pawn", "Knight", "Bishop", "Rook", "Queen", "King"
 			);
 
-			for rank in RankUtils::RANGE.rev() {
+			for rank in RankUtils::RANGE {
 				let mut combined_line = String::new();
 
 				for (piece, line) in lines.iter().enumerate() {

--- a/chess/src/board/zobrist.rs
+++ b/chess/src/board/zobrist.rs
@@ -1,5 +1,5 @@
 use super::{
-	castle_right::CastleRightConsts, color::ColorUtils, piece::PieceConsts, square::SquareUtils,
+	castle_right::CastleRightUtils, color::ColorUtils, piece::PieceConsts, square::SquareUtils,
 	CastleRight, Color, Piece, Square,
 };
 
@@ -7,7 +7,7 @@ use rand::Rng;
 
 type PieceTable = [[[ZobristHash; SquareUtils::SIZE]; Piece::PIECE_SIZE]; ColorUtils::SIZE];
 type ColorTable = [ZobristHash; ColorUtils::SIZE];
-type CastleTable = [ZobristHash; CastleRight::CASTLE_RIGHT_SIZE];
+type CastleTable = [ZobristHash; CastleRightUtils::SIZE];
 type EnPassantTable = [ZobristHash; SquareUtils::SIZE + 1];
 
 pub(crate) type ZobristHash = u64;
@@ -27,7 +27,7 @@ impl Default for HashTable {
 		let mut hash_table = Self {
 			pieces: [[[0; SquareUtils::SIZE]; Piece::PIECE_SIZE]; ColorUtils::SIZE],
 			colors: [0; ColorUtils::SIZE],
-			castles: [0; CastleRight::CASTLE_RIGHT_SIZE],
+			castles: [0; CastleRightUtils::SIZE],
 			en_passant: [0; SquareUtils::SIZE + 1],
 		};
 

--- a/chess/src/move_gen/mod.rs
+++ b/chess/src/move_gen/mod.rs
@@ -8,12 +8,12 @@ mod prelude;
 use crate::{
 	board::{
 		bitboard::BitboardUtils,
-		castle_right::CastleRights,
+		castle_right::CastleRightUtils,
 		color::ColorUtils,
 		file_rank::RankUtils,
 		piece::{PiecePromotions, Pieces},
 		square::SquareUtils,
-		Bitboard, Board, CastleRight, Piece, Square,
+		Bitboard, Board, Piece, Square,
 	},
 	move_list::MoveList,
 };
@@ -163,8 +163,8 @@ impl MoveGen {
 
 		let rights = board.castle_rights;
 
-		if color == ColorUtils::WHITE && rights & CastleRight::WHITE > 0 {
-			if rights & CastleRight::WHITE_KING > 0 {
+		if color == ColorUtils::WHITE && rights & CastleRightUtils::WHITE > 0 {
+			if rights & CastleRightUtils::WHITE_KING > 0 {
 				let blockers = BitboardUtils::SQUARES[SquareUtils::F1]
 					| BitboardUtils::SQUARES[SquareUtils::G1];
 
@@ -182,7 +182,7 @@ impl MoveGen {
 				}
 			}
 
-			if rights & CastleRight::WHITE_QUEEN > 0 {
+			if rights & CastleRightUtils::WHITE_QUEEN > 0 {
 				let blockers = BitboardUtils::SQUARES[SquareUtils::D1]
 					| BitboardUtils::SQUARES[SquareUtils::C1]
 					| BitboardUtils::SQUARES[SquareUtils::B1];
@@ -200,8 +200,8 @@ impl MoveGen {
 					);
 				}
 			}
-		} else if color == ColorUtils::BLACK && rights & CastleRight::BLACK > 0 {
-			if rights & CastleRight::BLACK_KING > 0 {
+		} else if color == ColorUtils::BLACK && rights & CastleRightUtils::BLACK > 0 {
+			if rights & CastleRightUtils::BLACK_KING > 0 {
 				let blockers = BitboardUtils::SQUARES[SquareUtils::F8]
 					| BitboardUtils::SQUARES[SquareUtils::G8];
 
@@ -219,7 +219,7 @@ impl MoveGen {
 				}
 			}
 
-			if rights & CastleRight::BLACK_QUEEN > 0 {
+			if rights & CastleRightUtils::BLACK_QUEEN > 0 {
 				let blockers = BitboardUtils::SQUARES[SquareUtils::D8]
 					| BitboardUtils::SQUARES[SquareUtils::C8]
 					| BitboardUtils::SQUARES[SquareUtils::B8];

--- a/chess/src/playmove.rs
+++ b/chess/src/playmove.rs
@@ -1,11 +1,7 @@
 use crate::{
 	board::{
-		bitboard::BitboardUtils,
-		castle_right::{CastleRightSquares, CastleRights},
-		color::ColorUtils,
-		piece::Pieces,
-		square::SquareUtils,
-		CastleRight, Piece,
+		bitboard::BitboardUtils, castle_right::CastleRightUtils, color::ColorUtils, piece::Pieces,
+		square::SquareUtils, Piece,
 	},
 	history::OldState,
 	move_gen::Move,
@@ -23,7 +19,7 @@ impl Chess {
 
 		let color = board.color;
 		let opponent = color ^ 1;
-		let has_caslte_rights = board.castle_rights != CastleRight::NONE;
+		let has_caslte_rights = board.castle_rights != CastleRightUtils::NONE;
 
 		let piece = m.piece();
 		let from = m.from();
@@ -40,7 +36,7 @@ impl Chess {
 			board.remove_piece(captured, opponent, to);
 
 			if captured == Piece::ROOK && has_caslte_rights {
-				board.update_castle_rights(board.castle_rights & !CastleRight::SQUARES[to]);
+				board.update_castle_rights(board.castle_rights & !CastleRightUtils::SQUARES[to]);
 			}
 		}
 
@@ -69,7 +65,7 @@ impl Chess {
 			board.add_piece(piece, color, to);
 
 			if (piece == Piece::KING || piece == Piece::ROOK) && has_caslte_rights {
-				board.update_castle_rights(board.castle_rights & !CastleRight::SQUARES[from]);
+				board.update_castle_rights(board.castle_rights & !CastleRightUtils::SQUARES[from]);
 			}
 
 			if m.castling() {


### PR DESCRIPTION
This is to prevent form importing multiple **traits** related to `castle_right`.