### PR TITLE
refactor: `piece` to use `PieceUtils` struct instead of traits

### DIFF
--- a/chess/src/board/impls/display.rs
+++ b/chess/src/board/impls/display.rs
@@ -1,8 +1,8 @@
 use castle_right::CastleRightUtils;
 use file_rank::{FileUtils, RankUtils};
+use piece::PieceUtils;
 use square::SquareUtils;
 
-use super::piece::PieceString;
 use super::*;
 use std::fmt;
 
@@ -16,7 +16,7 @@ impl Board {
 	fn get_piece(&self, square: Square) -> Option<(Piece, Color)> {
 		let piece = self.piece_list[square];
 
-		if piece == Piece::NONE {
+		if piece == PieceUtils::NONE {
 			None
 		} else {
 			for color in ColorUtils::RANGE {
@@ -37,7 +37,7 @@ impl Board {
 
 			for file in FileUtils::RANGE {
 				let piece = match self.get_piece(SquareUtils::from_location(file, rank)) {
-					Some((piece, color)) => piece.piece_string(color),
+					Some((piece, color)) => PieceUtils::to_string(piece, color),
 					None => " ".to_string(),
 				};
 
@@ -66,7 +66,7 @@ impl Board {
 							empty = 0;
 						}
 
-						pieces.push_str(&piece.piece_string(color));
+						pieces.push_str(&PieceUtils::to_string(piece, color));
 					}
 					None => empty += 1,
 				}

--- a/chess/src/board/impls/from.rs
+++ b/chess/src/board/impls/from.rs
@@ -1,9 +1,9 @@
 use bitboard::BitboardUtils;
 use castle_right::CastleRightUtils;
 use file_rank::{FileUtils, RankUtils};
+use piece::PieceUtils;
 use square::SquareUtils;
 
-use super::piece::{GetPiece, PieceConsts};
 use super::*;
 
 impl From<&str> for Board {
@@ -15,12 +15,12 @@ impl From<&str> for Board {
 impl From<(&str, Arc<HashTable>)> for Board {
 	fn from(value: (&str, Arc<HashTable>)) -> Self {
 		let mut board = Self {
-			pieces: [[BitboardUtils::EMPTY; usize::PIECE_SIZE]; ColorUtils::SIZE],
+			pieces: [[BitboardUtils::EMPTY; PieceUtils::SIZE]; ColorUtils::SIZE],
 			color: ColorUtils::WHITE,
 			en_passant: None,
 			castle_rights: CastleRight::default(),
 
-			piece_list: [Piece::NONE; SquareUtils::SIZE],
+			piece_list: [PieceUtils::NONE; SquareUtils::SIZE],
 			occupancy: BitboardUtils::EMPTY,
 			occupancy_color: [BitboardUtils::EMPTY; ColorUtils::SIZE],
 
@@ -103,7 +103,7 @@ impl BoardBuilder {
 				}
 				_ => {
 					board.add_piece(
-						Piece::get_piece(ch),
+						PieceUtils::parse(ch),
 						ColorUtils::from_bool(ch.is_uppercase()),
 						SquareUtils::from_location(file, rank),
 					);

--- a/chess/src/board/mod.rs
+++ b/chess/src/board/mod.rs
@@ -12,7 +12,7 @@ pub mod zobrist;
 
 use bitboard::BitboardUtils;
 use color::ColorUtils;
-use piece::Pieces;
+use piece::PieceUtils;
 use std::sync::Arc;
 use zobrist::{HashTable, ZobristHash};
 
@@ -58,7 +58,7 @@ impl Board {
 
 	#[inline(always)]
 	pub fn remove_piece(&mut self, piece: Piece, color: Color, square: Square) {
-		self.piece_list[square] = Piece::NONE;
+		self.piece_list[square] = PieceUtils::NONE;
 		self.pieces[color][piece] &= !(BitboardUtils::SQUARES[square]);
 
 		self.occupancy &= !(BitboardUtils::SQUARES[square]);

--- a/chess/src/board/piece.rs
+++ b/chess/src/board/piece.rs
@@ -2,35 +2,35 @@ use super::{color::ColorUtils, Color};
 
 pub type Piece = usize;
 
-pub trait Pieces {
-	const PAWN: Piece = 0;
-	const KNIGHT: Piece = 1;
-	const BISHOP: Piece = 2;
-	const ROOK: Piece = 3;
-	const QUEEN: Piece = 4;
-	const KING: Piece = 5;
-	const NONE: Piece = 6;
+pub struct PieceUtils;
+
+impl PieceUtils {
+	pub const SIZE: usize = 6;
+	pub const RANGE: std::ops::Range<usize> = 0..Self::SIZE;
 }
 
-pub trait PieceConsts {
-	const PIECE_SIZE: usize = 6;
-	const PIECE_RANGE: std::ops::Range<usize> = 0..Self::PIECE_SIZE;
+impl PieceUtils {
+	pub const PAWN: Piece = 0;
+	pub const KNIGHT: Piece = 1;
+	pub const BISHOP: Piece = 2;
+	pub const ROOK: Piece = 3;
+	pub const QUEEN: Piece = 4;
+	pub const KING: Piece = 5;
+	pub const NONE: Piece = 6;
 }
 
-pub trait PiecePromotions {
-	const PROMOTIONS: [Piece; 4] = [Piece::KNIGHT, Piece::BISHOP, Piece::ROOK, Piece::QUEEN];
+impl PieceUtils {
+	pub const PROMOTION_SIZE: usize = 4;
+	pub const PROMOTIONS: [Piece; Self::PROMOTION_SIZE] = [
+		PieceUtils::KNIGHT,
+		PieceUtils::BISHOP,
+		PieceUtils::ROOK,
+		PieceUtils::QUEEN,
+	];
 }
 
-impl Pieces for Piece {}
-impl PieceConsts for usize {}
-impl PiecePromotions for Piece {}
-
-pub trait GetPiece<T> {
-	fn get_piece(value: T) -> Self;
-}
-
-impl GetPiece<char> for Piece {
-	fn get_piece(value: char) -> Self {
+impl PieceUtils {
+	pub fn parse(value: char) -> Piece {
 		match value {
 			'P' | 'p' => Self::PAWN,
 			'N' | 'n' => Self::KNIGHT,
@@ -38,39 +38,33 @@ impl GetPiece<char> for Piece {
 			'R' | 'r' => Self::ROOK,
 			'Q' | 'q' => Self::QUEEN,
 			'K' | 'k' => Self::KING,
-			_ => panic!("Invalid piece: {value}"),
+			_ => panic!("Invalid piece: {}", value),
 		}
 	}
-}
 
-pub trait PieceString {
-	fn piece_string(&self, color: Color) -> String;
-}
-
-impl PieceString for Piece {
-	fn piece_string(&self, color: Color) -> String {
-		let ch = match *self {
-			Piece::PAWN => 'P',
-			Piece::KNIGHT => 'N',
-			Piece::BISHOP => 'B',
-			Piece::ROOK => 'R',
-			Piece::QUEEN => 'Q',
-			Piece::KING => 'K',
-			Piece::NONE => return String::from("None"),
-			_ => panic!("Invalid piece: {self}"),
+	pub fn to_string(piece: Piece, color: Color) -> String {
+		let ch = match piece {
+			Self::PAWN => 'P',
+			Self::KNIGHT => 'N',
+			Self::BISHOP => 'B',
+			Self::ROOK => 'R',
+			Self::QUEEN => 'Q',
+			Self::KING => 'K',
+			Self::NONE => return String::from("None"),
+			_ => panic!("Invalid piece: {piece}"),
 		};
 
 		String::from(match color {
 			ColorUtils::WHITE => ch,
 			ColorUtils::BLACK => ch.to_ascii_lowercase(),
 			ColorUtils::BOTH => {
-				let piece = match *self {
-					Piece::PAWN => "Pawn",
-					Piece::KNIGHT => "Knight",
-					Piece::BISHOP => "Bishop",
-					Piece::ROOK => "Rook",
-					Piece::QUEEN => "Queen",
-					Piece::KING => "King",
+				let piece = match piece {
+					Self::PAWN => "Pawn",
+					Self::KNIGHT => "Knight",
+					Self::BISHOP => "Bishop",
+					Self::ROOK => "Rook",
+					Self::QUEEN => "Queen",
+					Self::KING => "King",
 					_ => return String::from("None"),
 				};
 

--- a/chess/src/board/pieces.rs
+++ b/chess/src/board/pieces.rs
@@ -1,9 +1,9 @@
 use crate::board::{bitboard::BitboardUtils, file_rank::RankUtils};
 
-use super::{color::ColorUtils, piece::PieceConsts, square::SquareUtils, Bitboard, Color, Piece};
+use super::{color::ColorUtils, piece::PieceUtils, square::SquareUtils, Bitboard, Color, Piece};
 
 pub type PieceList = [Piece; SquareUtils::SIZE];
-pub type BitboardPieces = [[Bitboard; usize::PIECE_SIZE]; ColorUtils::SIZE];
+pub type BitboardPieces = [[Bitboard; PieceUtils::SIZE]; ColorUtils::SIZE];
 
 pub trait PrintBitboards {
 	fn print_bitboards(&self, color: Color);
@@ -17,12 +17,16 @@ impl PrintBitboards for BitboardPieces {
 				.map(|bitboard| BitboardUtils::to_string(*bitboard));
 
 			let lines = bitboards
-				.map(|s| s.lines().map(|s| s.to_string()).collect::<Vec<String>>())
-				.collect::<Vec<Vec<String>>>();
+				.map(|s| s.lines().map(|s| s.to_string()).collect::<Vec<_>>())
+				.collect::<Vec<_>>();
+
+			let piece = PieceUtils::RANGE
+				.map(|piece| PieceUtils::to_string(piece, ColorUtils::BOTH))
+				.collect::<Vec<_>>();
 
 			let mut output = format!(
 				"\n{:<17}{:<17}{:<17}{:<17}{:<17}{:<17}",
-				"Pawn", "Knight", "Bishop", "Rook", "Queen", "King"
+				piece[0], piece[1], piece[2], piece[3], piece[4], piece[5]
 			);
 
 			for rank in RankUtils::RANGE {

--- a/chess/src/board/zobrist.rs
+++ b/chess/src/board/zobrist.rs
@@ -1,11 +1,11 @@
 use super::{
-	castle_right::CastleRightUtils, color::ColorUtils, piece::PieceConsts, square::SquareUtils,
+	castle_right::CastleRightUtils, color::ColorUtils, piece::PieceUtils, square::SquareUtils,
 	CastleRight, Color, Piece, Square,
 };
 
 use rand::Rng;
 
-type PieceTable = [[[ZobristHash; SquareUtils::SIZE]; Piece::PIECE_SIZE]; ColorUtils::SIZE];
+type PieceTable = [[[ZobristHash; SquareUtils::SIZE]; PieceUtils::SIZE]; ColorUtils::SIZE];
 type ColorTable = [ZobristHash; ColorUtils::SIZE];
 type CastleTable = [ZobristHash; CastleRightUtils::SIZE];
 type EnPassantTable = [ZobristHash; SquareUtils::SIZE + 1];
@@ -25,7 +25,7 @@ impl Default for HashTable {
 		let mut random = rand::thread_rng();
 
 		let mut hash_table = Self {
-			pieces: [[[0; SquareUtils::SIZE]; Piece::PIECE_SIZE]; ColorUtils::SIZE],
+			pieces: [[[0; SquareUtils::SIZE]; PieceUtils::SIZE]; ColorUtils::SIZE],
 			colors: [0; ColorUtils::SIZE],
 			castles: [0; CastleRightUtils::SIZE],
 			en_passant: [0; SquareUtils::SIZE + 1],

--- a/chess/src/move_gen/impls/check.rs
+++ b/chess/src/move_gen/impls/check.rs
@@ -1,5 +1,5 @@
 use super::MoveGen;
-use crate::board::{piece::Pieces, Board, Color, Piece, Square};
+use crate::board::{piece::PieceUtils, Board, Color, Square};
 
 impl MoveGen {
 	#[inline(always)]
@@ -13,11 +13,11 @@ impl MoveGen {
 		let pawn = self.pawns[opponent ^ 1][square];
 		let queen = rook | bishop;
 
-		(king & board.pieces[opponent][Piece::KING] > 0)
-			|| (queen & board.pieces[opponent][Piece::QUEEN] > 0)
-			|| (rook & board.pieces[opponent][Piece::ROOK] > 0)
-			|| (bishop & board.pieces[opponent][Piece::BISHOP] > 0)
-			|| (knight & board.pieces[opponent][Piece::KNIGHT] > 0)
-			|| (pawn & board.pieces[opponent][Piece::PAWN] > 0)
+		(king & board.pieces[opponent][PieceUtils::KING] > 0)
+			|| (queen & board.pieces[opponent][PieceUtils::QUEEN] > 0)
+			|| (rook & board.pieces[opponent][PieceUtils::ROOK] > 0)
+			|| (bishop & board.pieces[opponent][PieceUtils::BISHOP] > 0)
+			|| (knight & board.pieces[opponent][PieceUtils::KNIGHT] > 0)
+			|| (pawn & board.pieces[opponent][PieceUtils::PAWN] > 0)
 	}
 }

--- a/chess/src/move_gen/impls/init.rs
+++ b/chess/src/move_gen/impls/init.rs
@@ -3,7 +3,7 @@ use crate::board::{
 	bitboard::BitboardUtils,
 	color::ColorUtils,
 	file_rank::{FileUtils, RankUtils},
-	piece::{PieceString, Pieces},
+	piece::PieceUtils,
 	square::SquareUtils,
 	Piece,
 };
@@ -21,8 +21,8 @@ impl Default for MoveGen {
 		};
 
 		move_gen.init_king();
-		move_gen.init_magic(Piece::ROOK);
-		move_gen.init_magic(Piece::BISHOP);
+		move_gen.init_magic(PieceUtils::ROOK);
+		move_gen.init_magic(PieceUtils::BISHOP);
 		move_gen.init_knight();
 		move_gen.init_pawn();
 
@@ -112,11 +112,11 @@ impl MoveGen {
 	// https://github.com/mvanthoor/rustic
 	fn init_magic(&mut self, piece: Piece) {
 		let is_rook = match piece {
-			Piece::ROOK => true,
-			Piece::BISHOP => false,
+			PieceUtils::ROOK => true,
+			PieceUtils::BISHOP => false,
 			_ => panic!(
 				"Invalid magic piece: {}",
-				piece.piece_string(ColorUtils::BOTH)
+				PieceUtils::to_string(piece, ColorUtils::BOTH)
 			),
 		};
 

--- a/chess/src/move_gen/magic.rs
+++ b/chess/src/move_gen/magic.rs
@@ -47,7 +47,7 @@ pub mod gen {
 	use std::time::Instant;
 
 	use super::super::{Magic, MoveGen, BISHOP_TABLE_SIZE, ROOK_TABLE_SIZE};
-	use crate::board::{bitboard::BitboardUtils, piece::Pieces, square::SquareUtils, Piece};
+	use crate::board::{bitboard::BitboardUtils, piece::PieceUtils, square::SquareUtils, Piece};
 	use rand::Rng;
 
 	impl Magic {
@@ -55,8 +55,8 @@ pub mod gen {
 			let start = Instant::now();
 
 			let is_rook = match piece {
-				Piece::ROOK => true,
-				Piece::BISHOP => false,
+				PieceUtils::ROOK => true,
+				PieceUtils::BISHOP => false,
 				_ => panic!("Invalid piece: {piece}"),
 			};
 

--- a/chess/src/move_gen/mod.rs
+++ b/chess/src/move_gen/mod.rs
@@ -7,13 +7,9 @@ mod prelude;
 
 use crate::{
 	board::{
-		bitboard::BitboardUtils,
-		castle_right::CastleRightUtils,
-		color::ColorUtils,
-		file_rank::RankUtils,
-		piece::{PiecePromotions, Pieces},
-		square::SquareUtils,
-		Bitboard, Board, Piece, Square,
+		bitboard::BitboardUtils, castle_right::CastleRightUtils, color::ColorUtils,
+		file_rank::RankUtils, piece::PieceUtils, square::SquareUtils, Bitboard, Board, Piece,
+		Square,
 	},
 	move_list::MoveList,
 };
@@ -34,12 +30,12 @@ impl MoveGen {
 	#[inline(always)]
 	pub fn king(&self, board: &Board, list: &mut MoveList) {
 		let color = board.color;
-		let mut piece = board.pieces[color][Piece::KING];
+		let mut piece = board.pieces[color][PieceUtils::KING];
 
 		let square = BitboardUtils::pop_lsb(&mut piece);
 		let moves = self.king[square] & !board.ally();
 
-		self.add_move(board, Piece::KING, square, moves, list);
+		self.add_move(board, PieceUtils::KING, square, moves, list);
 	}
 
 	#[inline(always)]
@@ -48,7 +44,7 @@ impl MoveGen {
 		let occupancy = board.occupancy;
 		let ally = board.ally();
 
-		let mut pieces = board.pieces[color][Piece::QUEEN];
+		let mut pieces = board.pieces[color][PieceUtils::QUEEN];
 
 		while pieces > 0 {
 			let square = BitboardUtils::pop_lsb(&mut pieces);
@@ -57,7 +53,7 @@ impl MoveGen {
 			let bishop_index = self.bishop_magics[square].index(occupancy);
 			let moves = (self.rooks[rook_index] | self.bishops[bishop_index]) & !ally;
 
-			self.add_move(board, Piece::QUEEN, square, moves, list);
+			self.add_move(board, PieceUtils::QUEEN, square, moves, list);
 		}
 	}
 
@@ -67,7 +63,7 @@ impl MoveGen {
 		let occupancy = board.occupancy;
 		let ally = board.ally();
 
-		let mut pieces = board.pieces[color][Piece::ROOK];
+		let mut pieces = board.pieces[color][PieceUtils::ROOK];
 
 		while pieces > 0 {
 			let square = BitboardUtils::pop_lsb(&mut pieces);
@@ -75,7 +71,7 @@ impl MoveGen {
 			let index = self.rook_magics[square].index(occupancy);
 			let moves = self.rooks[index] & !ally;
 
-			self.add_move(board, Piece::ROOK, square, moves, list);
+			self.add_move(board, PieceUtils::ROOK, square, moves, list);
 		}
 	}
 
@@ -85,7 +81,7 @@ impl MoveGen {
 		let occupancy = board.occupancy;
 		let ally = board.ally();
 
-		let mut pieces = board.pieces[color][Piece::BISHOP];
+		let mut pieces = board.pieces[color][PieceUtils::BISHOP];
 
 		while pieces > 0 {
 			let square = BitboardUtils::pop_lsb(&mut pieces);
@@ -93,7 +89,7 @@ impl MoveGen {
 			let index = self.bishop_magics[square].index(occupancy);
 			let moves = self.bishops[index] & !ally;
 
-			self.add_move(board, Piece::BISHOP, square, moves, list);
+			self.add_move(board, PieceUtils::BISHOP, square, moves, list);
 		}
 	}
 
@@ -102,13 +98,13 @@ impl MoveGen {
 		let color = board.color;
 		let ally = board.ally();
 
-		let mut pieces = board.pieces[color][Piece::KNIGHT];
+		let mut pieces = board.pieces[color][PieceUtils::KNIGHT];
 
 		while pieces > 0 {
 			let square = BitboardUtils::pop_lsb(&mut pieces);
 			let moves = self.knight[square] & !ally;
 
-			self.add_move(board, Piece::KNIGHT, square, moves, list);
+			self.add_move(board, PieceUtils::KNIGHT, square, moves, list);
 		}
 	}
 
@@ -132,7 +128,7 @@ impl MoveGen {
 
 		let rotation_count = (SquareUtils::SIZE + direction) as u32;
 
-		let mut pieces = board.pieces[color][Piece::PAWN];
+		let mut pieces = board.pieces[color][PieceUtils::PAWN];
 
 		while pieces > 0 {
 			let square = BitboardUtils::pop_lsb(&mut pieces);
@@ -151,7 +147,7 @@ impl MoveGen {
 
 			let moves = one_step | two_step | captures | en_passant;
 
-			self.add_move(board, Piece::PAWN, square, moves, list);
+			self.add_move(board, PieceUtils::PAWN, square, moves, list);
 		}
 	}
 
@@ -174,7 +170,7 @@ impl MoveGen {
 				{
 					self.add_move(
 						board,
-						Piece::KING,
+						PieceUtils::KING,
 						SquareUtils::E1,
 						BitboardUtils::SQUARES[SquareUtils::G1],
 						list,
@@ -193,7 +189,7 @@ impl MoveGen {
 				{
 					self.add_move(
 						board,
-						Piece::KING,
+						PieceUtils::KING,
 						SquareUtils::E1,
 						BitboardUtils::SQUARES[SquareUtils::C1],
 						list,
@@ -211,7 +207,7 @@ impl MoveGen {
 				{
 					self.add_move(
 						board,
-						Piece::KING,
+						PieceUtils::KING,
 						SquareUtils::E8,
 						BitboardUtils::SQUARES[SquareUtils::G8],
 						list,
@@ -230,7 +226,7 @@ impl MoveGen {
 				{
 					self.add_move(
 						board,
-						Piece::KING,
+						PieceUtils::KING,
 						SquareUtils::E8,
 						BitboardUtils::SQUARES[SquareUtils::C8],
 						list,
@@ -253,7 +249,7 @@ impl MoveGen {
 	) {
 		let mut moves = moves;
 		let color = board.color;
-		let is_pawn = Piece::PAWN == piece;
+		let is_pawn = PieceUtils::PAWN == piece;
 
 		let promotion_rank = match color {
 			ColorUtils::WHITE => RankUtils::R8,
@@ -273,7 +269,7 @@ impl MoveGen {
 			let promotion =
 				is_pawn && BitboardUtils::occupied(BitboardUtils::RANKS[promotion_rank], to);
 			let two_step = is_pawn && (to as i8 - from as i8).abs() == 16;
-			let castling = piece == Piece::KING && (from as i8 - to as i8).abs() == 2;
+			let castling = piece == PieceUtils::KING && (from as i8 - to as i8).abs() == 2;
 
 			let move_data = piece
 				| from << Move::FROM_SQUARE
@@ -284,9 +280,9 @@ impl MoveGen {
 				| (castling as usize) << Move::CASTLING;
 
 			if !promotion {
-				list.push(Move::new(move_data | Piece::NONE << Move::PROMOTION));
+				list.push(Move::new(move_data | PieceUtils::NONE << Move::PROMOTION));
 			} else {
-				for piece in Piece::PROMOTIONS {
+				for piece in PieceUtils::PROMOTIONS {
 					list.push(Move::new(move_data | piece << Move::PROMOTION));
 				}
 			}

--- a/chess/src/move_gen/piece_move.rs
+++ b/chess/src/move_gen/piece_move.rs
@@ -1,7 +1,7 @@
 // Marcel Vanthoor
 // https://github.com/mvanthoor/rustic
 
-use crate::board::{color::ColorUtils, piece::PieceString, square::SquareUtils, Piece, Square};
+use crate::board::{color::ColorUtils, piece::PieceUtils, square::SquareUtils, Piece, Square};
 use std::fmt::{self, Debug};
 
 #[derive(Copy, Clone, PartialEq)]
@@ -32,9 +32,9 @@ impl Debug for Move {
 			"{}{} {} {} {} {en_passant} {two_step} {castling}",
 			SquareUtils::to_string(from),
 			SquareUtils::to_string(to),
-			piece.piece_string(ColorUtils::BOTH),
-			captured.piece_string(ColorUtils::BOTH),
-			promoted.piece_string(ColorUtils::BOTH),
+			PieceUtils::to_string(piece, ColorUtils::BOTH),
+			PieceUtils::to_string(captured, ColorUtils::BOTH),
+			PieceUtils::to_string(promoted, ColorUtils::BOTH),
 		)
 	}
 }

--- a/chess/src/playmove.rs
+++ b/chess/src/playmove.rs
@@ -1,7 +1,7 @@
 use crate::{
 	board::{
-		bitboard::BitboardUtils, castle_right::CastleRightUtils, color::ColorUtils, piece::Pieces,
-		square::SquareUtils, Piece,
+		bitboard::BitboardUtils, castle_right::CastleRightUtils, color::ColorUtils,
+		piece::PieceUtils, square::SquareUtils,
 	},
 	history::OldState,
 	move_gen::Move,
@@ -31,22 +31,22 @@ impl Chess {
 			board.clear_en_passant();
 		}
 
-		if captured != Piece::NONE {
+		if captured != PieceUtils::NONE {
 			board.halfmove_clock = 0;
 			board.remove_piece(captured, opponent, to);
 
-			if captured == Piece::ROOK && has_caslte_rights {
+			if captured == PieceUtils::ROOK && has_caslte_rights {
 				board.update_castle_rights(board.castle_rights & !CastleRightUtils::SQUARES[to]);
 			}
 		}
 
-		if piece == Piece::PAWN {
+		if piece == PieceUtils::PAWN {
 			board.halfmove_clock = 0;
 
 			board.remove_piece(piece, color, from);
 			board.add_piece(
 				match promoted {
-					Piece::NONE => piece,
+					PieceUtils::NONE => piece,
 					_ => promoted,
 				},
 				color,
@@ -54,7 +54,7 @@ impl Chess {
 			);
 
 			if m.en_passant() {
-				board.remove_piece(Piece::PAWN, opponent, to ^ 8);
+				board.remove_piece(PieceUtils::PAWN, opponent, to ^ 8);
 			}
 
 			if m.two_step() {
@@ -64,27 +64,27 @@ impl Chess {
 			board.remove_piece(piece, color, from);
 			board.add_piece(piece, color, to);
 
-			if (piece == Piece::KING || piece == Piece::ROOK) && has_caslte_rights {
+			if (piece == PieceUtils::KING || piece == PieceUtils::ROOK) && has_caslte_rights {
 				board.update_castle_rights(board.castle_rights & !CastleRightUtils::SQUARES[from]);
 			}
 
 			if m.castling() {
 				match to {
 					SquareUtils::G1 => {
-						board.remove_piece(Piece::ROOK, color, SquareUtils::H1);
-						board.add_piece(Piece::ROOK, color, SquareUtils::F1);
+						board.remove_piece(PieceUtils::ROOK, color, SquareUtils::H1);
+						board.add_piece(PieceUtils::ROOK, color, SquareUtils::F1);
 					}
 					SquareUtils::C1 => {
-						board.remove_piece(Piece::ROOK, color, SquareUtils::A1);
-						board.add_piece(Piece::ROOK, color, SquareUtils::D1);
+						board.remove_piece(PieceUtils::ROOK, color, SquareUtils::A1);
+						board.add_piece(PieceUtils::ROOK, color, SquareUtils::D1);
 					}
 					SquareUtils::G8 => {
-						board.remove_piece(Piece::ROOK, color, SquareUtils::H8);
-						board.add_piece(Piece::ROOK, color, SquareUtils::F8);
+						board.remove_piece(PieceUtils::ROOK, color, SquareUtils::H8);
+						board.add_piece(PieceUtils::ROOK, color, SquareUtils::F8);
 					}
 					SquareUtils::C8 => {
-						board.remove_piece(Piece::ROOK, color, SquareUtils::A8);
-						board.add_piece(Piece::ROOK, color, SquareUtils::D8);
+						board.remove_piece(PieceUtils::ROOK, color, SquareUtils::A8);
+						board.add_piece(PieceUtils::ROOK, color, SquareUtils::D8);
 					}
 					_ => panic!("Invalid castling move: {}", SquareUtils::to_string(to)),
 				}
@@ -100,7 +100,7 @@ impl Chess {
 		let legal = !self.move_gen.square_attacked(
 			board,
 			opponent,
-			BitboardUtils::lsb(board.pieces[color][Piece::KING]),
+			BitboardUtils::lsb(board.pieces[color][PieceUtils::KING]),
 		);
 
 		if !legal {
@@ -132,42 +132,42 @@ impl Chess {
 			let captured = m.captured();
 			let promoted = m.promoted();
 
-			if m.promoted() == Piece::NONE {
+			if m.promoted() == PieceUtils::NONE {
 				board.remove_piece(piece, color, to);
 				board.add_piece(piece, color, from);
 
 				if m.castling() {
 					match to {
 						SquareUtils::G1 => {
-							board.remove_piece(Piece::ROOK, color, SquareUtils::F1);
-							board.add_piece(Piece::ROOK, color, SquareUtils::H1);
+							board.remove_piece(PieceUtils::ROOK, color, SquareUtils::F1);
+							board.add_piece(PieceUtils::ROOK, color, SquareUtils::H1);
 						}
 						SquareUtils::C1 => {
-							board.remove_piece(Piece::ROOK, color, SquareUtils::D1);
-							board.add_piece(Piece::ROOK, color, SquareUtils::A1);
+							board.remove_piece(PieceUtils::ROOK, color, SquareUtils::D1);
+							board.add_piece(PieceUtils::ROOK, color, SquareUtils::A1);
 						}
 						SquareUtils::G8 => {
-							board.remove_piece(Piece::ROOK, color, SquareUtils::F8);
-							board.add_piece(Piece::ROOK, color, SquareUtils::H8);
+							board.remove_piece(PieceUtils::ROOK, color, SquareUtils::F8);
+							board.add_piece(PieceUtils::ROOK, color, SquareUtils::H8);
 						}
 						SquareUtils::C8 => {
-							board.remove_piece(Piece::ROOK, color, SquareUtils::D8);
-							board.add_piece(Piece::ROOK, color, SquareUtils::A8);
+							board.remove_piece(PieceUtils::ROOK, color, SquareUtils::D8);
+							board.add_piece(PieceUtils::ROOK, color, SquareUtils::A8);
 						}
 						_ => panic!("Invalid castling move: {}", SquareUtils::to_string(to)),
 					}
 				}
 			} else {
 				board.remove_piece(promoted, color, to);
-				board.add_piece(Piece::PAWN, color, from);
+				board.add_piece(PieceUtils::PAWN, color, from);
 			}
 
-			if captured != Piece::NONE {
+			if captured != PieceUtils::NONE {
 				board.add_piece(captured, color ^ 1, to);
 			}
 
 			if m.en_passant() {
-				board.add_piece(Piece::PAWN, color ^ 1, to ^ 8);
+				board.add_piece(PieceUtils::PAWN, color ^ 1, to ^ 8);
 			}
 
 			board.hash = state.hash;

--- a/engine/src/args.rs
+++ b/engine/src/args.rs
@@ -1,5 +1,5 @@
 use chess::{
-	board::{color::ColorUtils, piece::Pieces, pieces::PrintBitboards, Board, Color},
+	board::{color::ColorUtils, pieces::PrintBitboards, Board, Color},
 	move_gen::MoveGen,
 	Chess,
 };
@@ -85,11 +85,14 @@ pub fn perft(depth: u8, fen: String, threads: usize, hash: Option<String>) {
 
 #[cfg(debug_assertions)]
 pub fn magic(piece: MagicPiece) {
-	use chess::{board::Piece, move_gen::Magic};
+	use chess::{
+		board::{piece::PieceUtils, Piece},
+		move_gen::Magic,
+	};
 
 	let piece = match piece {
-		MagicPiece::Rook => Piece::ROOK,
-		MagicPiece::Bishop => Piece::BISHOP,
+		MagicPiece::Rook => PieceUtils::ROOK,
+		MagicPiece::Bishop => PieceUtils::BISHOP,
 	};
 
 	Magic::generate(piece);


### PR DESCRIPTION
This is to prevent form importing multiple **traits** related to `piece`.