### PR TITLE
refactor: `pieces` to use `BitboardPiecesUtils` struct instead of traits

### DIFF
--- a/chess/src/board/pieces.rs
+++ b/chess/src/board/pieces.rs
@@ -5,13 +5,11 @@ use super::{color::ColorUtils, piece::PieceUtils, square::SquareUtils, Bitboard,
 pub type PieceList = [Piece; SquareUtils::SIZE];
 pub type BitboardPieces = [[Bitboard; PieceUtils::SIZE]; ColorUtils::SIZE];
 
-pub trait PrintBitboards {
-	fn print_bitboards(&self, color: Color);
-}
+pub struct BitboardPiecesUtils;
 
-impl PrintBitboards for BitboardPieces {
-	fn print_bitboards(&self, color: Color) {
-		if let Some(bitboards) = self.get(color) {
+impl BitboardPiecesUtils {
+	pub fn to_string(bb_pieces: &BitboardPieces, color: Color) {
+		if let Some(bitboards) = bb_pieces.get(color) {
 			let bitboards = bitboards
 				.iter()
 				.map(|bitboard| BitboardUtils::to_string(*bitboard));

--- a/engine/src/args.rs
+++ b/engine/src/args.rs
@@ -1,5 +1,5 @@
 use chess::{
-	board::{color::ColorUtils, pieces::PrintBitboards, Board, Color},
+	board::{color::ColorUtils, pieces::BitboardPiecesUtils, Board, Color},
 	move_gen::MoveGen,
 	Chess,
 };
@@ -64,9 +64,9 @@ pub fn display(fen: Option<String>, bitboards: bool) {
 		false => println!("{board}"),
 		true => {
 			println!("White Pieces:");
-			board.pieces.print_bitboards(ColorUtils::WHITE);
+			BitboardPiecesUtils::to_string(&board.pieces, ColorUtils::WHITE);
 			println!("Black Pieces:");
-			board.pieces.print_bitboards(ColorUtils::BLACK);
+			BitboardPiecesUtils::to_string(&board.pieces, ColorUtils::BLACK);
 		}
 	}
 }


### PR DESCRIPTION
This is to prevent form importing multiple **traits** related to `pieces`.