### PR TITLE
Performance/improvements

### DIFF
--- a/chess/src/move_list.rs
+++ b/chess/src/move_list.rs
@@ -22,14 +22,14 @@ impl Default for MoveList {
 	}
 }
 
-impl<'a> IntoIterator for &'a MoveList {
-	type Item = &'a Move;
-	type IntoIter = std::slice::Iter<'a, Move>;
-
-	fn into_iter(self) -> Self::IntoIter {
-		self.list[..self.count].iter()
-	}
-}
+//impl<'a> IntoIterator for &'a MoveList {
+//	type Item = &'a Move;
+//	type IntoIter = std::slice::Iter<'a, Move>;
+//
+//	fn into_iter(self) -> Self::IntoIter {
+//		self.list[..self.count].iter()
+//	}
+//}
 
 impl MoveList {
 	#[inline(always)]
@@ -49,5 +49,9 @@ impl MoveList {
 			.chunks(chunk_size)
 			.map(|chunk| chunk.to_vec())
 			.collect()
+	}
+
+	pub fn iter(&self) -> std::slice::Iter<Move> {
+		self.list[..self.count].iter()
 	}
 }

--- a/chess/src/transposition.rs
+++ b/chess/src/transposition.rs
@@ -1,57 +1,90 @@
 use crate::board::zobrist::ZobristHash;
 
-use papaya::{HashMap, LocalGuard};
-
-#[derive(Default)]
-pub struct TranspositionTable<V> {
-	entries: HashMap<ZobristHash, V>,
-	max_capacity: usize,
-}
-
-impl<V> TranspositionTable<V>
-where
-	V: Depth,
-{
-	pub fn new(bytes: usize) -> Self {
-		let max_capacity = bytes / std::mem::size_of::<(ZobristHash, V)>();
-
-		Self {
-			max_capacity,
-			entries: HashMap::with_capacity(max_capacity),
-		}
-	}
-
-	pub fn insert(&self, key: ZobristHash, data: V) {
-		let guard = self.entries.guard();
-
-		if self.entries.len() >= self.max_capacity {
-			// TODO: Remove the hightest depth entry.
-			//       Might have to consider using a different data structure.
-
-			return;
-		}
-
-		self.entries.insert(key, data, &guard);
-	}
-
-	pub fn get<'a>(&self, key: &ZobristHash, guard: &'a LocalGuard) -> Option<&'a V> {
-		self.entries.get(key, guard)
-	}
-
-	pub fn clear(&self) {
-		self.entries.clear(&self.entries.guard());
-	}
-
-	pub fn guard(&self) -> LocalGuard {
-		self.entries.guard()
-	}
-}
+const ENTRIES_PER_BUCKET: usize = 4;
+const HIGH_FOUR_BYTES: u64 = 0xFF_FF_FF_FF_00_00_00_00;
+const LOW_FOUR_BYTES: u64 = 0x00_00_00_00_FF_FF_FF_FF;
+const SHIFT_TO_LOWER: u64 = 32;
 
 pub trait Depth {
 	fn depth(&self) -> u8;
 }
 
+#[derive(Default, Clone)]
+pub struct Entry<V> {
+	data: V,
+	verification: u32,
+}
+
+#[derive(Default, Clone)]
+pub struct Bucket<V>([Entry<V>; ENTRIES_PER_BUCKET]);
+
+impl<V: Depth> Bucket<V> {
+	pub fn insert(&mut self, verification: u32, data: V) {
+		let mut idx_lowest_depth = 0;
+
+		for (idx, entry) in self.0.iter().enumerate() {
+			if entry.data.depth() < data.depth() {
+				idx_lowest_depth = idx;
+			}
+		}
+
+		self.0[idx_lowest_depth] = Entry { data, verification };
+	}
+
+	pub fn get(&self, verification: u32) -> Option<&V> {
+		for entry in self.0.iter() {
+			if entry.verification == verification {
+				return Some(&entry.data);
+			}
+		}
+
+		None
+	}
+}
+
 #[derive(Default)]
+pub struct TranspositionTable<V> {
+	entries: Vec<Bucket<V>>,
+}
+
+impl<V: Depth + Default + Clone> TranspositionTable<V> {
+	pub fn new(bytes: usize) -> Self {
+		let total_buckets = bytes / std::mem::size_of::<Bucket<V>>();
+
+		Self {
+			entries: vec![Bucket::default(); total_buckets],
+		}
+	}
+
+	pub fn insert(&mut self, hash: ZobristHash, data: V) {
+		let index = self.calculate_index(hash);
+		let verification = self.calculate_verification(hash);
+
+		self.entries[index].insert(verification, data);
+	}
+
+	pub fn get(&self, hash: ZobristHash) -> Option<&V> {
+		let index = self.calculate_index(hash);
+		let verification = self.calculate_verification(hash);
+
+		self.entries[index].get(verification)
+	}
+}
+
+impl<V> TranspositionTable<V> {
+	fn calculate_index(&self, hash: ZobristHash) -> usize {
+		let key = (hash & HIGH_FOUR_BYTES) >> SHIFT_TO_LOWER;
+		let total = self.entries.len() as u64;
+
+		(key % total) as usize
+	}
+
+	fn calculate_verification(&self, hash: ZobristHash) -> u32 {
+		(hash & LOW_FOUR_BYTES) as u32
+	}
+}
+
+#[derive(Default, Clone)]
 pub struct PerftData {
 	depth: u8,
 	nodes: usize,


### PR DESCRIPTION
Improve the hashing by changing the `entries` data type to `Vec<Bucket<Entry<V>>>`. This now replaces the lowest `depth` from the bucket when inserting a board position onto the `TranspositionTable`.